### PR TITLE
[TBL109] A pipeline to deploy cloudfoundry apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# IDE
+.idea/
+
+# Secrets
+secrets.yml

--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ CI/CD pipeline for RAS services.
 
 1. Copy `secrets.yml.example` to `secrets.yml`
 1. Assign values to all secret variables
-1. Login to concourse `fly -t lite login -c $CONCOURSE_HOST`
+1. Login to concourse `fly -t lite login -c http://localhost:8080`
 1. Deploy the pipeline `./deploy-pipeline.sh`

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # ras-deploy
-RAS CD pipeline
+
+CI/CD pipeline for RAS services.
+
+![pipeline](https://i.imgur.com/HA4ENhA.png)
+
+## Deploying pipeline
+
+1. Copy `secrets.yml.example` to `secrets.yml`
+1. Assign values to all secret variables
+1. Login to concourse `fly -t lite login -c $CONCOURSE_HOST`
+1. Deploy the pipeline `./deploy-pipeline.sh`

--- a/README.md
+++ b/README.md
@@ -6,8 +6,14 @@ CI/CD pipeline for RAS services.
 
 ## Deploying pipeline
 
+1. Install fly cli
+```bash
+wget https://github.com/concourse/concourse/releases/download/v3.5.0/fly_darwin_amd64
+chmod +x fly_darwin_amd64
+sudo mv fly_darwin_amd64 /usr/local/bin/fly
+```
 1. Copy `secrets.yml.example` to `secrets.yml`
 1. Assign values to all secret variables
 1. Login to concourse `fly -t lite login -c http://localhost:8080`
-1. Deploy the pipeline `./deploy-pipeline.sh`
-1. Go to [ras-deploy](http://localhost:8080/teams/main/pipelines/ras-deploy)
+1. Deploy the pipeline `fly -t lite set-pipeline -p ras-deploy -c concourse/ras-deploy.yml  --load-vars-from concourse/secrets.yml`
+1. Go to <concourse-host>/teams/main/pipelines/ras-deploy e.g. http://localhost:8080/teams/main/pipelines/ras-deploy

--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ CI/CD pipeline for RAS services.
 1. Assign values to all secret variables
 1. Login to concourse `fly -t lite login -c http://localhost:8080`
 1. Deploy the pipeline `./deploy-pipeline.sh`
+1. Go to [ras-deploy](http://localhost:8080/teams/main/pipelines/ras-deploy)

--- a/concourse/ras-deploy.yml
+++ b/concourse/ras-deploy.yml
@@ -1,6 +1,4 @@
 resources:
-
-resources:
 - name: ras-party-source
   type: git
   source:
@@ -47,7 +45,6 @@ resources:
   type: git
   source:
     uri: https://github.com/ONSdigital/django-oauth2-test.git
-    branch: tbl109-pipelines
 
 - name: ras-integration-tests-source
   type: git
@@ -273,11 +270,46 @@ jobs:
   plan:
   - get: django-oauth2-test-source
     trigger: true
+#    Create git_info file for info end point
+  - task: git_info
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: paasmule/curl-ssl-git
+          tag: "latest"
+      inputs:
+        - name: django-oauth2-test-source
+      outputs:
+        - name: django-oauth2-test-source-git-info
+      run:
+        path: sh
+        args:
+        - -exc
+        - |
+          cd django-oauth2-test-source
+          branch=$(git rev-parse --abbrev-ref HEAD)
+          url=$(git config --get remote.origin.url)
+          commit=$(git rev-parse HEAD)
+          repo=$(basename `git rev-parse --show-toplevel`)
+          when=`date --utc +%FT%TZ`
+          output=git_info
+          echo '{' > ${output}
+          echo   \"origin\": \"${url}\", >> ${output}
+          echo   \"commit\": \"${commit}\", >> ${output}
+          echo   \"branch\": \"${branch}\", >> ${output}
+          echo   \"name\": \"${repo}\", >> ${output}
+          echo   \"built\": \"${when}\" >> ${output}
+          echo '}' >> ${output}
+          cd ..
+          cp -r django-oauth2-test-source/* django-oauth2-test-source-git-info
+
   - put: cf-resource-dev
     params:
       current_app_name: concourse-django-oauth2-test.dev
-      manifest: django-oauth2-test-source/manifest.yml
-      path: django-oauth2-test-source
+      manifest: django-oauth2-test-source-git-info/manifest.yml
+      path: django-oauth2-test-source-git-info
       environment_variables:
         CSRF_ENABLED: "True"
         DEBUG: "False"
@@ -319,6 +351,22 @@ jobs:
   - get: ras-collection-instrument-source
     passed: [ras-collection-instrument-dev-deploy]
     trigger: true
+  - task: build_test
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: python
+          tag: "latest"
+      inputs:
+        - name: ras-integration-tests-source
+      run:
+        path: sh
+        args:
+        - -exc
+        - |
+          echo "Passed"
 
 - name: ras-party-test-deploy
   plan:
@@ -544,11 +592,45 @@ jobs:
   - get: django-oauth2-test-source
     passed: [ras-integration-tests]
     trigger: true
+#    Create git_info file for info end point
+  - task: git_info
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: paasmule/curl-ssl-git
+          tag: "latest"
+      inputs:
+        - name: django-oauth2-test-source
+      outputs:
+        - name: django-oauth2-test-source-git-info
+      run:
+        path: sh
+        args:
+        - -exc
+        - |
+          cd django-oauth2-test-source
+          branch=$(git rev-parse --abbrev-ref HEAD)
+          url=$(git config --get remote.origin.url)
+          commit=$(git rev-parse HEAD)
+          repo=$(basename `git rev-parse --show-toplevel`)
+          when=`date --utc +%FT%TZ`
+          output=git_info
+          echo '{' > ${output}
+          echo   \"origin\": \"${url}\", >> ${output}
+          echo   \"commit\": \"${commit}\", >> ${output}
+          echo   \"branch\": \"${branch}\", >> ${output}
+          echo   \"name\": \"${repo}\", >> ${output}
+          echo   \"built\": \"${when}\" >> ${output}
+          echo '}' >> ${output}
+          cd ..
+          cp -r django-oauth2-test-source/* django-oauth2-test-source-git-info
   - put: cf-resource-test
     params:
       current_app_name: concourse-django-oauth2-test.test
-      manifest: django-oauth2-test-source/manifest.yml
-      path: django-oauth2-test-source
+      manifest: django-oauth2-test-source-git-info/manifest.yml
+      path: django-oauth2-test-source-git-info
       environment_variables:
         CSRF_ENABLED: "True"
         DEBUG: "False"

--- a/concourse/ras-deploy.yml
+++ b/concourse/ras-deploy.yml
@@ -1,0 +1,563 @@
+resources:
+
+resources:
+- name: ras-party-source
+  type: git
+  source:
+    uri: https://github.com/ONSdigital/ras-party.git
+    branch: tbl109-pipelines
+
+- name: ras-secure-message-source
+  type: git
+  source:
+    uri: https://github.com/ONSdigital/ras-secure-message.git
+    branch: tbl109-pipelines
+
+- name: ras-backstage-source
+  type: git
+  source:
+    uri: https://github.com/ONSdigital/ras-backstage.git
+    branch: tbl109-pipelines
+
+- name: ras-backstage-ui-source
+  type: git
+  source:
+    uri: https://github.com/ONSdigital/ras-backstage-ui.git
+    branch: tbl109-pipelines
+
+- name: ras-api-gateway-source
+  type: git
+  source:
+    uri: https://github.com/ONSdigital/ras-api-gateway.git
+    branch: tbl109-pipelines
+
+- name: ras-collection-instrument-source
+  type: git
+  source:
+    uri: https://github.com/ONSdigital/ras-collection-instrument.git
+    branch: tbl109-pipelines
+
+- name: ras-frontstage-source
+  type: git
+  source:
+    uri: https://github.com/ONSdigital/ras-frontstage.git
+    branch: tbl109-pipelines
+
+- name: django-oauth2-test-source
+  type: git
+  source:
+    uri: https://github.com/ONSdigital/django-oauth2-test.git
+    branch: tbl109-pipelines
+
+- name: ras-integration-tests-source
+  type: git
+  source:
+    uri: https://github.com/ONSdigital/ras-integration-tests.git
+
+- name: cf-resource-dev
+  type: cf
+  source:
+    api: {{cloudfoundry_api}}
+    username: {{cloudfoundry_email}}
+    password: {{cloudfoundry_password}}
+    organization: rmras
+    space: dev
+    skip_cert_check: true
+
+- name: cf-resource-test
+  type: cf
+  source:
+    api: {{cloudfoundry_api}}
+    username: {{cloudfoundry_email}}
+    password: {{cloudfoundry_password}}
+    organization: rmras
+    space: test
+    skip_cert_check: true
+
+jobs:
+- name: ras-party-dev-deploy
+  plan:
+  - get: ras-party-source
+    trigger: true
+  - put: cf-resource-dev
+    params:
+      current_app_name: concourse-ras-party.dev
+      manifest: ras-party-source/manifest.yml
+      path: ras-party-source
+      environment_variables:
+        SECURITY_USER_NAME: {{dev_security_user_name}}
+        SECURITY_USER_PASSWORD: {{dev_security_user_password}}
+        case-service.host: 'casesvc-dev.apps.devtest.onsclofo.uk'
+        case-service.port: '80'
+        collectionexercise-service.host: 'collectionexercisesvc-dev.apps.devtest.onsclofo.uk'
+        collectionexercise-service.port: '80'
+        survey-service.host: 'surveysvc-dev.apps.devtest.onsclofo.uk'
+        survey-service.port: '80'
+        oauth2-service.host: 'concourse-django-oauth2-testdev.apps.devtest.onsclofo.uk'
+        oauth2-service.port: '80'
+        iac-service.host: 'iacsvc-dev.apps.devtest.onsclofo.uk'
+        iac-service.port: '80'
+        frontstage-service.host: 'ras-frontstage-dev.apps.devtest.onsclofo.uk'
+        frontstage-service.port: '80'
+        feature.send_email_to_gov_notify: 'false'
+        gov-uk-notify-service.gov_notify_api_key: {{notify_api_key}}
+        gov-uk-notify-service.gov_notify_template_id: '53c59576-8c3b-4298-99d1-b245ddd28500'
+        gov-uk-notify-service.gov_notify_service_id: 'ce3674b1-7b08-4377-a6a7-05b5722d4ea5'
+
+- name: ras-secure-message-dev-deploy
+  plan:
+  - get: ras-secure-message-source
+    trigger: true
+  - put: cf-resource-dev
+    params:
+      current_app_name: concourse-ras-secure-message.dev
+      manifest: ras-secure-message-source/manifest.yml
+      path: ras-secure-message-source
+      environment_variables:
+        DEV_PORT: '8080'
+        JWT_ALGORITHM: 'HS256'
+        JWT_SECRET: {{dev_secret_key}}
+        NOFITY_CASE_SERVICE: '1'
+        NOTIFICATION_API_KEY: {{notify_api_key}}
+        SERVICE_ID: 'aa1de51c-955b-4d83-83b2-d266525feacd'
+        NOTIFICATION_TEMPLATE_ID: 'f6404844-a994-428c-a5d7-45a4e1cfff4b'
+        NOTIFY_VIA_GOV_NOTIFY: '1'
+        ONS_ENV: 'dev'
+        RAS_PARTY_SERVICE_PORT: '80'
+        RAS_PARTY_SERVICE_HOST: 'concourse-ras-partydev.apps.devtest.onsclofo.uk'
+        RAS_SM_PATH: '/home/vcap/app'
+        SECURITY_USER_NAME: {{dev_security_user_name}}
+        SECURITY_USER_PASSWORD: {{dev_security_user_password}}
+        SMS_LOG_LEVEL: 'DEBUG'
+        SM_JWT_ENCRYPT: '0'
+
+- name: ras-backstage-dev-deploy
+  plan:
+  - get: ras-backstage-source
+    trigger: true
+  - put: cf-resource-dev
+    params:
+      current_app_name: concourse-ras-backstage.dev
+      manifest: ras-backstage-source/manifest.yml
+      path: ras-backstage-source
+      environment_variables:
+        SECURITY_USER_NAME: {{dev_security_user_name}}
+        SECURITY_USER_PASSWORD: {{dev_security_user_password}}
+        case-service.host: 'casesvc-dev.apps.devtest.onsclofo.uk'
+        case-service.port: '80'
+        collectionexercise-service.host: 'collectionexercisesvc-dev.apps.devtest.onsclofo.uk'
+        collectionexercise-service.port: '80'
+        survey-service.host: 'surveysvc-dev.apps.devtest.onsclofo.uk'
+        survey-service.port: '80'
+        oauth2-service.host: 'concourse-django-oauth2-testdev.apps.devtest.onsclofo.uk'
+        oauth2-service.port: '80'
+        party-service.host: 'concourse-ras-partydev.apps.devtest.onsclofo.uk'
+        party-service.port: '80'
+        secure-message-service.host: 'concourse-ras-secure-messagedev.apps.devtest.onsclofo.uk'
+        secure-message-service.port: '80'
+        collection-instrument-service.host: 'ras-collection-instrument-dev.apps.devtest.onsclofo.uk'
+        collection-instrument-service.port: '80'
+
+- name: ras-backstage-ui-dev-deploy
+  plan:
+  - get: ras-backstage-ui-source
+    trigger: true
+  - put: cf-resource-dev
+    params:
+      current_app_name: concourse-ras-backstage-ui.dev
+      manifest: ras-backstage-ui-source/manifest.yml
+      path: ras-backstage-ui-source
+      environment_variables:
+        ONS_ENV: 'dev'
+        SECURITY_USER_NAME: {{dev_security_user_name}}
+        SECURITY_USER_PASSWORD: {{dev_security_user_password}}
+
+- name: ras-api-gateway-dev-deploy
+  plan:
+  - get: ras-api-gateway-source
+    trigger: true
+  - put: cf-resource-dev
+    params:
+      current_app_name: concourse-ras-api-gateway.dev
+      manifest: ras-api-gateway-source/manifest.yml
+      path: ras-api-gateway-source
+      environment_variables:
+        ONS_ENV: 'dev'
+        RAS_COLLECTION_INSTRUMENT_SERVICE_HOST: 'concourse-ras-collection-instrumentdev.apps.devtest.onsclofo.uk'
+        RAS_COLLECTION_INSTRUMENT_SERVICE_PORT: '80'
+        RAS_PARTY_SERVICE_HOST: 'concourse-ras-partydev.apps.devtest.onsclofo.uk'
+        RAS_PARTY_SERVICE_PORT: '80'
+        RAS_SECURE_MESSAGING_SERVICE_HOST: 'concourse-ras-secure-messagedev.apps.devtest.onsclofo.uk'
+        RAS_SECURE_MESSAGING_SERVICE_PORT: '80'
+        RM_ACTION_SERVICE_HOST: 'actionsvc-dev.apps.devtest.onsclofo.uk'
+        RM_ACTION_SERVICE_PORT: '80'
+        RM_CASE_SERVICE_HOST: 'casesvc-dev.apps.devtest.onsclofo.uk'
+        RM_CASE_SERVICE_PORT: '80'
+        RM_COLLECTIONEXERCISE_SERVICE_HOST: 'collectionexercisesvc-dev.apps.devtest.onsclofo.uk'
+        RM_COLLECTIONEXERCISE_SERVICE_PORT: '80'
+        RM_IAC_SERVICE_HOST: 'iacsvc-dev.apps.devtest.onsclofo.uk'
+        RM_IAC_SERVICE_PORT: '80'
+        RM_NOTIFY_GATEWAY_SERVICE_HOST: 'notifygatewaysvc-dev.apps.devtest.onsclofo.uk'
+        RM_NOTIFY_GATEWAY_SERVICE_PORT: '80'
+        RM_SAMPLE_SERVICE_HOST: 'samplesvc-dev.apps.devtest.onsclofo.uk'
+        RM_SAMPLE_SERVICE_PORT: '80'
+        RM_SURVEY_SURVEY_HOST: 'surveysvc-dev.apps.devtest.onsclofo.uk'
+        RM_SURVEY_SURVEY_PORT: '80'
+        SECURITY_USER_NAME: {{dev_security_user_name}}
+        SECURITY_USER_PASSWORD: {{dev_security_user_password}}
+
+- name: ras-collection-instrument-dev-deploy
+  plan:
+  - get: ras-collection-instrument-source
+    trigger: true
+  - put: cf-resource-dev
+    params:
+      current_app_name: concourse-ras-collection-instrument.dev
+      manifest: ras-collection-instrument-source/manifest.yml
+      path: ras-collection-instrument-source
+      environment_variables:
+        API_GATEWAY_CASE_URL: 'http://concourse-ras-api-gatewaydev.apps.devtest.onsclofo.uk:80/cases/'
+        API_GATEWAY_COLLECTION_EXERCISE_URL: 'http://concourse-ras-api-gatewaydev.apps.devtest.onsclofo.uk:80/collectionexercises/'
+        API_HOST: 'concourse-ras-api-gatewaydev.apps.devtest.onsclofo.uk'
+        API_PORT: '80'
+        ONS_ENV: 'dev'
+        RABBITMQ_AMQP: {{dev_rabbitmq_amqp}}
+        SECURITY_USER_NAME: {{dev_security_user_name}}
+        SECURITY_USER_PASSWORD: {{dev_security_user_password}}
+
+- name: ras-frontstage-dev-deploy
+  plan:
+  - get: ras-frontstage-source
+    trigger: true
+  - put: cf-resource-dev
+    params:
+      current_app_name: concourse-ras-frontstage.dev
+      manifest: ras-frontstage-source/manifest.yml
+      path: ras-frontstage-source
+      environment_variables:
+        API_GATEWAY_AGGREGATED_SURVEYS_URL: 'http://concourse-ras-api-gatewaydev.apps.devtest.onsclofo.uk/api/1.0.0/surveys/'
+        API_GATEWAY_COLLECTION_INSTRUMENT_URL: 'http://concourse-ras-api-gatewaydev.apps.devtest.onsclofo.uk/collection-instrument-api/1.0.2/'
+        API_GATEWAY_PARTY_URL: 'http://concourse-ras-api-gatewaydev.apps.devtest.onsclofo.uk/party-api/1.0.4/'
+        API_GATEWAY_SURVEYS_URL: 'http://concourse-ras-api-gatewaydev.apps.devtest.onsclofo.uk/surveys/'
+        DEV_PORT: '8080'
+        JWT_ALGORITHM: 'HS256'
+        JWT_SECRET: {{dev_secret_key}}
+        ONS_ENV: 'test'
+        ONS_OAUTH_HOST: 'concourse-django-oauth2-testdev.apps.devtest.onsclofo.uk'
+        ONS_OAUTH_PROTOCOL: 'http'
+        RAS_API_GATEWAY_SERVICE_HOST: 'concourse-ras-api-gatewaydev.apps.devtest.onsclofo.uk'
+        RAS_API_GATEWAY_SERVICE_PORT: '80'
+        RAS_COLLECTION_INSTRUMENT_SERVICE_HOST: 'concourse-ras-collection-instrumentdev.apps.devtest.onsclofo.uk'
+        RAS_COLLECTION_INSTRUMENT_SERVICE_PORT: '80'
+        RAS_FRONTSTAGE_CLIENT_ID: 'ons@ons.gov'
+        RAS_FRONTSTAGE_CLIENT_SECRET: 'password'
+        RAS_FRONTSTAGE_LOGGING_LEVEL: 'DEBUG'
+        RAS_PARTY_SERVICE_HOST: 'concourse-ras-partydev.apps.devtest.onsclofo.uk'
+        RAS_PARTY_SERVICE_PORT: '80'
+        RAS_SECURE_MESSAGE_SERVICE_HOST: 'concourse-ras-secure-messagedev.apps.devtest.onsclofo.uk'
+        RAS_SECURE_MESSAGE_SERVICE_PORT: '80'
+        RM_CASE_SERVICE_HOST: 'casesvc-test.apps.devtest.onsclofo.uk'
+        RM_CASE_SERVICE_PORT: '80'
+        RM_COLLECTION_EXERCISE_SERVICE_HOST: 'collectionexercisesvc-test.apps.devtest.onsclofo.uk'
+        RM_COLLECTION_EXERCISE_SERVICE_PORT: '80'
+        RM_IAC_SERVICE_HOST: 'iacsvc-test.apps.devtest.onsclofo.uk'
+        RM_IAC_SERVICE_PORT: '80'
+        RM_SURVEY_SERVICE_HOST: 'surveysvc-test.apps.devtest.onsclofo.uk'
+        RM_SURVEY_SERVICE_PORT: '80'
+        SECRET_KEY: {{dev_secret_key}}
+        SM_URL: 'http://concourse-ras-api-gatewaydev.apps.devtest.onsclofo.uk'
+        SECURITY_USER_NAME: {{dev_security_user_name}}
+        SECURITY_USER_PASSWORD: {{dev_security_user_password}}
+
+- name: django-oauth2-test-dev-deploy
+  plan:
+  - get: django-oauth2-test-source
+    trigger: true
+  - put: cf-resource-dev
+    params:
+      current_app_name: concourse-django-oauth2-test.dev
+      manifest: django-oauth2-test-source/manifest.yml
+      path: django-oauth2-test-source
+      environment_variables:
+        CSRF_ENABLED: "True"
+        DEBUG: "False"
+        DJANGO_SETTINGS_MODULE: proj.settings.cloud_foundry_settings
+        OAUTH2_SUPER_USER: {{dev_oauth2_super_user}}
+        OAUTH2_SUPER_USER_EMAIL: {{dev_oauth2_super_user_email}}
+        OAUTH2_SUPER_USER_PASSWORD: {{dev_oauth2_super_user_password}}
+        SECRET_KEY: {{dev_secret_key}}
+        TESTING: "False"
+        SECURITY_USER_NAME: {{dev_security_user_name}}
+        SECURITY_USER_PASSWORD: {{dev_security_user_password}}
+
+
+- name: ras-integration-tests
+  plan:
+  - get: ras-integration-tests-source
+    trigger: true
+  - get: ras-party-source
+    passed: [ras-party-dev-deploy]
+    trigger: true
+  - get: ras-backstage-source
+    passed: [ras-backstage-dev-deploy]
+    trigger: true
+  - get: ras-frontstage-source
+    passed: [ras-frontstage-dev-deploy]
+    trigger: true
+  - get: ras-api-gateway-source
+    passed: [ras-api-gateway-dev-deploy]
+    trigger: true
+  - get: ras-backstage-ui-source
+    passed: [ras-backstage-ui-dev-deploy]
+    trigger: true
+  - get: django-oauth2-test-source
+    passed: [django-oauth2-test-dev-deploy]
+    trigger: true
+  - get: ras-secure-message-source
+    passed: [ras-secure-message-dev-deploy]
+    trigger: true
+  - get: ras-collection-instrument-source
+    passed: [ras-collection-instrument-dev-deploy]
+    trigger: true
+
+- name: ras-party-test-deploy
+  plan:
+  - get: ras-party-source
+    passed: [ras-integration-tests]
+    trigger: true
+  - put: cf-resource-test
+    params:
+      current_app_name: concourse-ras-party.test
+      manifest: ras-party-source/manifest.yml
+      path: ras-party-source
+      environment_variables:
+        SECURITY_USER_NAME: {{test_security_user_name}}
+        SECURITY_USER_PASSWORD: {{test_security_user_password}}
+        case-service.host: 'casesvc-test.apps.devtest.onsclofo.uk'
+        case-service.port: '80'
+        collectionexercise-service.host: 'collectionexercisesvc-test.apps.devtest.onsclofo.uk'
+        collectionexercise-service.port: '80'
+        survey-service.host: 'surveysvc-test.apps.devtest.onsclofo.uk'
+        survey-service.port: '80'
+        oauth2-service.host: 'concourse-django-oauth2-testtest.apps.devtest.onsclofo.uk'
+        oauth2-service.port: '80'
+        iac-service.host: 'iacsvc-test.apps.devtest.onsclofo.uk'
+        iac-service.port: '80'
+        frontstage-service.host: 'concourse-ras-frontstagetest.apps.devtest.onsclofo.uk'
+        frontstage-service.port: '80'
+        api-gateway.host: 'concourse-ras-api-gatewaytest.apps.devtest.onsclofo.uk'
+        frontstage-service.port: '80'
+        features.gateway_registration: 'true'
+        feature.send_email_to_gov_notify: 'true'
+        gov-uk-notify-service.gov_notify_api_key: {{notify_api_key}}
+        gov-uk-notify-service.gov_notify_template_id: '53c59576-8c3b-4298-99d1-b245ddd28500'
+        gov-uk-notify-service.gov_notify_service_id: 'ce3674b1-7b08-4377-a6a7-05b5722d4ea5'
+        PUBLIC_EMAIL_VERIFICATION_URL: 'www.ons.gov.uk/surveys/get-started'
+        SECRET_KEY: 'aardvark'
+        EMAIL_TOKEN_SALT: 'sdc'
+
+- name: ras-secure-message-test-deploy
+  plan:
+  - get: ras-secure-message-source
+    passed: [ras-integration-tests]
+    trigger: true
+  - put: cf-resource-test
+    params:
+      current_app_name: concourse-ras-secure-message.test
+      manifest: ras-secure-message-source/manifest.yml
+      path: ras-secure-message-source
+      environment_variables:
+        DEV_PORT: '8080'
+        NOFITY_CASE_SERVICE: '1'
+        NOTIFICATION_API_KEY: {{notify_api_key}}
+        SERVICE_ID: 'aa1de51c-955b-4d83-83b2-d266525feacd'
+        NOTIFICATION_TEMPLATE_ID: 'f6404844-a994-428c-a5d7-45a4e1cfff4b'
+        NOTIFY_VIA_GOV_NOTIFY: '1'
+        NOTIFY_VIA_LOGGING: '1'
+        ONS_ENV: 'test'
+        RAS_PARTY_SERVICE_PORT: '80'
+        RAS_PARTY_SERVICE_HOST: 'concourse-ras-partytest.apps.devtest.onsclofo.uk'
+        RAS_SM_PATH: '/home/vcap/app'
+        SECURITY_USER_NAME: {{test_security_user_name}}
+        SECURITY_USER_PASSWORD: {{test_security_user_password}}
+        SMS_LOG_LEVEL: 'DEBUG'
+        SM_JWT_ENCRYPT: '0'
+
+- name: ras-backstage-test-deploy
+  plan:
+  - get: ras-backstage-source
+    passed: [ras-integration-tests]
+    trigger: true
+  - put: cf-resource-test
+    params:
+      current_app_name: concourse-ras-backstage.test
+      manifest: ras-backstage-source/manifest.yml
+      path: ras-backstage-source
+      environment_variables:
+        SECURITY_USER_NAME: {{test_security_user_name}}
+        SECURITY_USER_PASSWORD: {{test_security_user_password}}
+        case-service.host: 'casesvc-test.apps.devtest.onsclofo.uk'
+        case-service.port: '80'
+        collectionexercise-service.host: 'collectionexercisesvc-test.apps.devtest.onsclofo.uk'
+        collectionexercise-service.port: '80'
+        survey-service.host: 'surveysvc-test.apps.devtest.onsclofo.uk'
+        survey-service.port: '80'
+        oauth2-service.host: 'concourse-django-oauth2-testtest.apps.devtest.onsclofo.uk'
+        oauth2-service.port: '80'
+        iac-service.host: 'iacsvc-test.apps.devtest.onsclofo.uk'
+        iac-service.port: '80'
+        frontstage-service.host: 'concourse-ras-frontstagetest.apps.devtest.onsclofo.uk'
+        frontstage-service.port: '80'
+        api-gateway.host: 'concourse-ras-api-gatewaytest.apps.devtest.onsclofo.uk'
+        api-gateway.port: '80'
+        features.gateway_registration: 'true'
+        party-service.host: 'concourse-ras-partytest.apps.devtest.onsclofo.uk'
+        party-service.port: '80'
+        secure-message-service.host: 'concourse-ras-secure-messagetest.apps.devtest.onsclofo.uk'
+        secure-message-service.port: '80'
+        collection-instrument-service.host: 'ras-collection-instrument-test.apps.devtest.onsclofo.uk'
+        collection-instrument-service.port: '80'
+        SECRET_KEY: {{test_secret_key}}
+
+- name: ras-backstage-ui-test-deploy
+  plan:
+  - get: ras-backstage-ui-source
+    passed: [ras-integration-tests]
+    trigger: true
+  - put: cf-resource-test
+    params:
+      current_app_name: concourse-ras-backstage-ui.test
+      manifest: ras-backstage-ui-source/manifest.yml
+      path: ras-backstage-ui-source
+      environment_variables:
+        ONS_ENV: 'test'
+        SECURITY_USER_NAME: {{test_security_user_name}}
+        SECURITY_USER_PASSWORD: {{test_security_user_password}}
+
+- name: ras-api-gateway-test-deploy
+  plan:
+  - get: ras-api-gateway-source
+    passed: [ras-integration-tests]
+    trigger: true
+  - put: cf-resource-test
+    params:
+      current_app_name: concourse-ras-api-gateway.test
+      manifest: ras-api-gateway-source/manifest.yml
+      path: ras-api-gateway-source
+      environment_variables:
+        ONS_ENV: 'test'
+        RAS_COLLECTION_INSTRUMENT_SERVICE_HOST: 'concourse-ras-collection-instrumenttest.apps.devtest.onsclofo.uk'
+        RAS_COLLECTION_INSTRUMENT_SERVICE_PORT: '80'
+        RAS_PARTY_SERVICE_HOST: 'concourse-ras-partytest.apps.devtest.onsclofo.uk'
+        RAS_PARTY_SERVICE_PORT: '80'
+        RAS_SECURE_MESSAGING_SERVICE_HOST: 'concourse-ras-secure-messagetest.apps.devtest.onsclofo.uk'
+        RAS_SECURE_MESSAGING_SERVICE_PORT: '80'
+        RM_ACTION_SERVICE_HOST: 'actionsvc-test.apps.devtest.onsclofo.uk'
+        RM_ACTION_SERVICE_PORT: '80'
+        RM_CASE_SERVICE_HOST: 'casesvc-test.apps.devtest.onsclofo.uk'
+        RM_CASE_SERVICE_PORT: '80'
+        RM_COLLECTIONEXERCISE_SERVICE_HOST: 'collectionexercisesvc-test.apps.devtest.onsclofo.uk'
+        RM_COLLECTIONEXERCISE_SERVICE_PORT: '80'
+        RM_IAC_SERVICE_HOST: 'iacsvc-test.apps.devtest.onsclofo.uk'
+        RM_IAC_SERVICE_PORT: '80'
+        RM_NOTIFY_GATEWAY_SERVICE_HOST: 'notifygatewaysvc-test.apps.devtest.onsclofo.uk'
+        RM_NOTIFY_GATEWAY_SERVICE_PORT: '80'
+        RM_SAMPLE_SERVICE_HOST: 'samplesvc-test.apps.devtest.onsclofo.uk'
+        RM_SAMPLE_SERVICE_PORT: '80'
+        RM_SURVEY_SURVEY_HOST: 'surveysvc-test.apps.devtest.onsclofo.uk'
+        RM_SURVEY_SURVEY_PORT: '80'
+        SECURITY_USER_NAME: {{test_security_user_name}}
+        SECURITY_USER_PASSWORD: {{test_security_user_password}}
+        LOG_FORMAT: 'json'
+
+- name: ras-collection-instrument-test-deploy
+  plan:
+  - get: ras-collection-instrument-source
+    passed: [ras-integration-tests]
+    trigger: true
+  - put: cf-resource-test
+    params:
+      current_app_name: concourse-ras-collection-instrument.test
+      manifest: ras-collection-instrument-source/manifest.yml
+      path: ras-collection-instrument-source
+      environment_variables:
+        API_GATEWAY_CASE_URL: 'http://concourse-ras-api-gatewaytest.apps.devtest.onsclofo.uk:80/cases/'
+        API_GATEWAY_COLLECTION_EXERCISE_URL: 'http://concourse-ras-api-gatewaytest.apps.devtest.onsclofo.uk:80/collectionexercises/'
+        API_GATEWAY_SURVEY_SERVICE_URL: 'http://concourse-ras-api-gatewaytest.apps.devtest.onsclofo.uk:80/surveys/'
+        API_HOST: 'concourse-ras-api-gatewaytest.apps.devtest.onsclofo.uk'
+        API_PORT: '80'
+        ONS_ENV: 'test'
+        RABBITMQ_AMQP: {{test_rabbitmq_amqp}}
+        SECURITY_USER_NAME: {{test_security_user_name}}
+        SECURITY_USER_PASSWORD: {{test_security_user_password}}
+        ONS_CRYPTOKEY: {{test_ons_cryptokey}}
+        JSON_SECRET_KEYS: {{test_json_secret_keys}}
+        LOG_FORMAT: 'json'
+
+- name: ras-frontstage-test-deploy
+  plan:
+  - get: ras-frontstage-source
+    passed: [ras-integration-tests]
+    trigger: true
+  - put: cf-resource-test
+    params:
+      current_app_name: concourse-ras-frontstage.test
+      manifest: ras-frontstage-source/manifest.yml
+      path: ras-frontstage-source
+      environment_variables:
+        API_GATEWAY_AGGREGATED_SURVEYS_URL: 'http://concourse-ras-api-gatewaytest.apps.devtest.onsclofo.uk/api/1.0.0/surveys/'
+        API_GATEWAY_COLLECTION_INSTRUMENT_URL: 'http://concourse-ras-api-gatewaytest.apps.devtest.onsclofo.uk/collection-instrument-api/1.0.2/'
+        API_GATEWAY_PARTY_URL: 'http://concourse-ras-api-gatewaytest.apps.devtest.onsclofo.uk/party-api/1.0.4/'
+        API_GATEWAY_SURVEYS_URL: 'http://concourse-ras-api-gatewaytest.apps.devtest.onsclofo.uk/surveys/'
+        DEV_PORT: '8080'
+        JWT_ALGORITHM: 'HS256'
+        JWT_SECRET: {{test_secret_key}}
+        ONS_ENV: 'test'
+        ONS_OAUTH_HOST: 'concourse-django-oauth2-testtest.apps.devtest.onsclofo.uk'
+        ONS_OAUTH_PROTOCOL: 'http'
+        RAS_API_GATEWAY_SERVICE_HOST: 'concourse-ras-api-gatewaytest.apps.devtest.onsclofo.uk'
+        RAS_API_GATEWAY_SERVICE_PORT: '80'
+        RAS_COLLECTION_INSTRUMENT_SERVICE_HOST: 'concourse-ras-collection-instrumenttest.apps.devtest.onsclofo.uk'
+        RAS_COLLECTION_INSTRUMENT_SERVICE_PORT: '80'
+        RAS_FRONTSTAGE_CLIENT_ID: 'ons@ons.gov'
+        RAS_FRONTSTAGE_CLIENT_SECRET: 'password'
+        RAS_FRONTSTAGE_LOGGING_LEVEL: 'DEBUG'
+        RAS_PARTY_SERVICE_HOST: 'concourse-ras-partytest.apps.devtest.onsclofo.uk'
+        RAS_PARTY_SERVICE_PORT: '80'
+        RAS_SECURE_MESSAGE_SERVICE_HOST: 'concourse-ras-secure-messagetest.apps.devtest.onsclofo.uk'
+        RAS_SECURE_MESSAGE_SERVICE_PORT: '80'
+        RM_CASE_SERVICE_HOST: 'casesvc-test.apps.devtest.onsclofo.uk'
+        RM_CASE_SERVICE_PORT: '80'
+        RM_COLLECTION_EXERCISE_SERVICE_HOST: 'collectionexercisesvc-test.apps.devtest.onsclofo.uk'
+        RM_COLLECTION_EXERCISE_SERVICE_PORT: '80'
+        RM_IAC_SERVICE_HOST: 'iacsvc-test.apps.devtest.onsclofo.uk'
+        RM_IAC_SERVICE_PORT: '80'
+        RM_SURVEY_SERVICE_HOST: 'surveysvc-test.apps.devtest.onsclofo.uk'
+        RM_SURVEY_SERVICE_PORT: '80'
+        SECRET_KEY: {{test_secret_key}}
+        SM_URL: 'http://concourse-ras-api-gatewaytest.apps.devtest.onsclofo.uk'
+        SECURITY_USER_NAME: {{test_security_user_name}}
+        SECURITY_USER_PASSWORD: {{test_security_user_password}}
+
+- name: django-oauth2-test-test-deploy
+  plan:
+  - get: django-oauth2-test-source
+    passed: [ras-integration-tests]
+    trigger: true
+  - put: cf-resource-test
+    params:
+      current_app_name: concourse-django-oauth2-test.test
+      manifest: django-oauth2-test-source/manifest.yml
+      path: django-oauth2-test-source
+      environment_variables:
+        CSRF_ENABLED: "True"
+        DEBUG: "False"
+        DJANGO_SETTINGS_MODULE: proj.settings.cloud_foundry_settings
+        OAUTH2_SUPER_USER: {{test_oauth2_super_user}}
+        OAUTH2_SUPER_USER_EMAIL: {{test_oauth2_super_user_email}}
+        OAUTH2_SUPER_USER_PASSWORD: {{test_oauth2_super_user_password}}
+        SECRET_KEY: {{test_secret_key}}
+        TESTING: "False"
+        SECURITY_USER_NAME: {{test_security_user_name}}
+        SECURITY_USER_PASSWORD: {{test_security_user_password}}
+

--- a/concourse/secrets.yml.example
+++ b/concourse/secrets.yml.example
@@ -1,0 +1,29 @@
+# Cloudfoundry credentials
+cloudfoundry_email: 
+cloudfoundry_password: 
+cloudfoundry_api: 
+
+# Global secrets
+notify_api_key: 
+
+# Dev secrets
+dev_security_user_name: 
+dev_security_user_password: 
+dev_secure_message_jwt_secret: 
+dev_secret_key: 
+dev_oauth2_super_user: 
+dev_oauth2_super_user_email: 
+dev_oauth2_super_user_password: 
+dev_rabbitmq_amqp: 
+
+# Test secrets
+test_security_user_name: 
+test_security_user_password: 
+test_secure_message_jwt_secret:
+test_secret_key: 
+test_oauth2_super_user: 
+test_oauth2_super_user_email: 
+test_oauth2_super_user_password: 
+test_rabbitmq_amqp: 
+test_ons_cryptokey: 
+test_json_secret_keys: 

--- a/deploy-pipeline.sh
+++ b/deploy-pipeline.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-fly -t lite set-pipeline -p ras-deploy -c concourse/ras-deploy.yml  --load-vars-from concourse/secrets.yml

--- a/deploy-pipeline.sh
+++ b/deploy-pipeline.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+fly -t lite set-pipeline -p ras-deploy -c concourse/ras-deploy.yml  --load-vars-from concourse/secrets.yml


### PR DESCRIPTION
# Trello
https://trello.com/c/2OLpREcU/610-tbl109-p3-ras-ci-pipeline-build-packaging-spike

# Testing
1. Clone https://github.com/concourse/concourse-docker
1. Edit docker-compose.yml
    - Set `CONCOURSE_BASIC_AUTH_USERNAME=concourse`
    - Set `CONCOURSE_BASIC_AUTH_PASSWORD=changeme`
    - Delete `CONCOURSE_NO_REALLY_I_DONT_WANT_ANY_AUTH`
1. Follow steps in https://concourse.ci/docker-repository.html after "create docker-compose.yml"
1. Follow readme in PR
1. Unpause pipeline if you want to run it

# Info

Take a look at the rendered readme to see the pipeline https://github.com/ONSdigital/ras-deploy/tree/tbl109-pipelines

For each repository there is a pipeline which starts when there is a
commit to a repository. An example pipeline looks like:

ras-party -> deploy to dev -> integration test -> deploy to test

If any step along that path fails the next task will not execute.

The integration test task is currently a placeholder for when the tests
are implemented.