### PR TITLE
Adding http:// scheme to party url

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -85,7 +85,7 @@ templates:
       IAC_SERVICE_PORT: '80'
       NOTIFY_GATEWAY_SERVICE_HOST: rm-notify-gateway-ci.apps.devtest.onsclofo.uk
       NOTIFY_GATEWAY_SERVICE_PORT: '80'
-      PARTY_URL: ras-party-ci.apps.devtest.onsclofo.uk
+      PARTY_URL: http://ras-party-ci.apps.devtest.onsclofo.uk
       PARTY_SERVICE_HOST: ras-party-ci.apps.devtest.onsclofo.uk
       PARTY_SERVICE_PORT: '80'
       RM_CASE_SERVICE_HOST: rm-case-service-ci.apps.devtest.onsclofo.uk
@@ -276,7 +276,7 @@ templates:
       IAC_SERVICE_PORT: '80'
       NOTIFY_GATEWAY_SERVICE_HOST: rm-notify-gateway-concourse-latest.apps.devtest.onsclofo.uk
       NOTIFY_GATEWAY_SERVICE_PORT: '80'
-      PARTY_URL: ras-party-concourse-latest.apps.devtest.onsclofo.uk
+      PARTY_URL: http://ras-party-concourse-latest.apps.devtest.onsclofo.uk
       PARTY_SERVICE_HOST: ras-party-concourse-latest.apps.devtest.onsclofo.uk
       PARTY_SERVICE_PORT: '80'
       RM_CASE_SERVICE_HOST: rm-case-service-concourse-latest.apps.devtest.onsclofo.uk
@@ -467,7 +467,7 @@ templates:
       IAC_SERVICE_PORT: '80'
       NOTIFY_GATEWAY_SERVICE_HOST: rm-notify-gateway-concourse-preprod.apps.devtest.onsclofo.uk
       NOTIFY_GATEWAY_SERVICE_PORT: '80'
-      PARTY_URL: ras-party-concourse-preprod.apps.devtest.onsclofo.uk
+      PARTY_URL: http://ras-party-concourse-preprod.apps.devtest.onsclofo.uk
       PARTY_SERVICE_HOST: ras-party-concourse-preprod.apps.devtest.onsclofo.uk
       PARTY_SERVICE_PORT: '80'
       RM_CASE_SERVICE_HOST: rm-case-service-concourse-preprod.apps.devtest.onsclofo.uk
@@ -658,7 +658,7 @@ templates:
       IAC_SERVICE_PORT: '80'
       NOTIFY_GATEWAY_SERVICE_HOST: rm-notify-gateway-concourse-prod.apps.devtest.onsclofo.uk
       NOTIFY_GATEWAY_SERVICE_PORT: '80'
-      PARTY_URL: ras-party-concourse-prod.apps.devtest.onsclofo.uk
+      PARTY_URL: http://ras-party-concourse-prod.apps.devtest.onsclofo.uk
       PARTY_SERVICE_HOST: ras-party-concourse-prod.apps.devtest.onsclofo.uk
       PARTY_SERVICE_PORT: '80'
       RM_CASE_SERVICE_HOST: rm-case-service-concourse-prod.apps.devtest.onsclofo.uk


### PR DESCRIPTION
# What is the issue
When the response operations services tries to speak to ras-party the
environment variable it uses is the host without the http:// schema.
This causes the service to raise an exception
`equests.exceptions.MissingSchema: Invalid URL
'ras-party-ci.apps.devtest.onsclofo.uk/party-api/v1/parties/type/B/ref/49900000001':
No schema supplied. Perhaps you meant
http://ras-party-ci.apps.devtest.onsclofo.uk/party-api/v1/parties/type/B/ref/49900000001?`

# What is the fix
Changing all of the PARTY_URL variables to have the schema should fix
this.

# How to test
Fly the pipeline, kick off job to deploy ras-party and check there are more acceptance tests passing 
