### PR TITLE
Add environment variables.

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -34,6 +34,8 @@ templates:
       PARTY_PASSWORD: ((ci_security_user_password))
       SURVEY_USERNAME: ((ci_security_user_name))
       SURVEY_PASSWORD: ((ci_security_user_password))
+      SAMPLE_USERNAME: ((ci_security_user_name))
+      SAMPLE_PASWORD: ((ci_security_user_password))
 
     all_services: &ci_all_services
     - ras-party-ci-deploy
@@ -126,6 +128,8 @@ templates:
       RESPONSE_OPERATIONS_UI_PORT: '80'
       SAMPLE_SERVICE_HOST: rm-sample-service-ci.apps.devtest.onsclofo.uk
       SAMPLE_SERVICE_PORT: '80'
+      SAMPLE_HOST: rm-sample-service-ci.apps.devtest.onsclofo.uk
+      SAMPLE_PORT: '80'
       SECURE_MESSAGE_SERVICE_HOST: ras-secure-message-ci.apps.devtest.onsclofo.uk
       SECURE_MESSAGE_SERVICE_PORT: '80'
       SURVEY_SERVICE_HOST: rm-survey-service-ci.apps.devtest.onsclofo.uk
@@ -225,6 +229,8 @@ templates:
       PARTY_PASSWORD: ((latest_security_user_password))
       SURVEY_USERNAME: ((latest_security_user_name))
       SURVEY_PASSWORD: ((latest_security_user_password))
+      SAMPLE_USERNAME: ((latest_security_user_name))
+      SAMPLE_PASSWORD: ((latest_security_user_password))
 
     all_services: &latest_all_services
     - ras-party-latest-deploy
@@ -315,6 +321,8 @@ templates:
       RESPONSE_OPERATIONS_UI_PORT: '80'
       SAMPLE_SERVICE_HOST: rm-sample-service-concourse-latest.apps.devtest.onsclofo.uk
       SAMPLE_SERVICE_PORT: '80'
+      SAMPLE_HOST: rm-sample-service-concourse-latest.apps.devtest.onsclofo.uk
+      SAMPLE:PORT: '80'
       SECURE_MESSAGE_URL: http://ras-secure-message-concourse-latest.apps.devtest.onsclofo.uk
       SECURE_MESSAGE_SERVICE_HOST: ras-secure-message-concourse-latest.apps.devtest.onsclofo.uk
       SECURE_MESSAGE_SERVICE_PORT: '80'
@@ -416,6 +424,8 @@ templates:
       PARTY_PASSWORD: ((preprod_security_user_password))
       SURVEY_USERNAME: ((preprod_security_user_name))
       SURVEY_PASSWORD: ((preprod_security_user_password))
+      SAMPLE_USERNAME: ((preprod_security_user_name))
+      SAMPLE_PASSWORD: ((preprod_security_user_password))
 
     all_services: &preprod_all_services
     - ras-party-preprod-deploy
@@ -506,6 +516,8 @@ templates:
       RESPONSE_OPERATIONS_UI_PORT: '80'
       SAMPLE_SERVICE_HOST: rm-sample-service-concourse-preprod.apps.devtest.onsclofo.uk
       SAMPLE_SERVICE_PORT: '80'
+      SAMPLE_HOST: rm-sample-service-concourse-preprod.apps.devtest.onsclofo.uk
+      SAMPLE_PORT: '80'
       SECURE_MESSAGE_URL: http://ras-secure-message-concourse-preprod.apps.devtest.onsclofo.uk
       SECURE_MESSAGE_SERVICE_HOST: ras-secure-message-concourse-preprod.apps.devtest.onsclofo.uk
       SECURE_MESSAGE_SERVICE_PORT: '80'
@@ -607,6 +619,8 @@ templates:
       PARTY_PASSWORD: ((prod_security_user_password))
       SURVEY_USERNAME: ((prod_security_user_name))
       SURVEY_PASSWORD: ((prod_security_user_password))
+      SAMPLE_USERNAME: ((prod_security_user_name))
+      SAMPLE_PASSWORD: ((prod_security_user_password))
 
     all_services: &prod_all_services
     - ras-party-prod-deploy
@@ -697,6 +711,8 @@ templates:
       RESPONSE_OPERATIONS_UI_PORT: '80'
       SAMPLE_SERVICE_HOST: rm-sample-service-concourse-prod.apps.devtest.onsclofo.uk
       SAMPLE_SERVICE_PORT: '80'
+      SAMPLE_HOST: rm-sample-service-concourse-prod.apps.devtest.onsclofo.uk
+      SAMPLE_PORT: '80'
       SECURE_MESSAGE_URL: http://ras-secure-message-concourse-prod.apps.devtest.onsclofo.uk
       SECURE_MESSAGE_SERVICE_HOST: ras-secure-message-concourse-prod.apps.devtest.onsclofo.uk
       SECURE_MESSAGE_SERVICE_PORT: '80'

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -128,8 +128,7 @@ templates:
       RESPONSE_OPERATIONS_UI_PORT: '80'
       SAMPLE_SERVICE_HOST: rm-sample-service-ci.apps.devtest.onsclofo.uk
       SAMPLE_SERVICE_PORT: '80'
-      SAMPLE_HOST: rm-sample-service-ci.apps.devtest.onsclofo.uk
-      SAMPLE_PORT: '80'
+      SAMPLE_URL: http://rm-sample-service-ci.apps.devtest.onsclofo.uk
       SECURE_MESSAGE_SERVICE_HOST: ras-secure-message-ci.apps.devtest.onsclofo.uk
       SECURE_MESSAGE_SERVICE_PORT: '80'
       SURVEY_SERVICE_HOST: rm-survey-service-ci.apps.devtest.onsclofo.uk
@@ -321,8 +320,7 @@ templates:
       RESPONSE_OPERATIONS_UI_PORT: '80'
       SAMPLE_SERVICE_HOST: rm-sample-service-concourse-latest.apps.devtest.onsclofo.uk
       SAMPLE_SERVICE_PORT: '80'
-      SAMPLE_HOST: rm-sample-service-concourse-latest.apps.devtest.onsclofo.uk
-      SAMPLE:PORT: '80'
+      SAMPLE_URL: http://rm-sample-service-concourse-latest.apps.devtest.onsclofo.uk
       SECURE_MESSAGE_URL: http://ras-secure-message-concourse-latest.apps.devtest.onsclofo.uk
       SECURE_MESSAGE_SERVICE_HOST: ras-secure-message-concourse-latest.apps.devtest.onsclofo.uk
       SECURE_MESSAGE_SERVICE_PORT: '80'
@@ -516,8 +514,7 @@ templates:
       RESPONSE_OPERATIONS_UI_PORT: '80'
       SAMPLE_SERVICE_HOST: rm-sample-service-concourse-preprod.apps.devtest.onsclofo.uk
       SAMPLE_SERVICE_PORT: '80'
-      SAMPLE_HOST: rm-sample-service-concourse-preprod.apps.devtest.onsclofo.uk
-      SAMPLE_PORT: '80'
+      SAMPLE_URL: http://rm-sample-service-concourse-preprod.apps.devtest.onsclofo.uk
       SECURE_MESSAGE_URL: http://ras-secure-message-concourse-preprod.apps.devtest.onsclofo.uk
       SECURE_MESSAGE_SERVICE_HOST: ras-secure-message-concourse-preprod.apps.devtest.onsclofo.uk
       SECURE_MESSAGE_SERVICE_PORT: '80'
@@ -584,7 +581,7 @@ templates:
         service_instance: rm-pg-db
         timeout: 1800
         wait_for_service: true
-        
+
   prod:
     security_user: &prod_security_user
       actionSvc_connectionConfig_password: ((prod_security_user_password))
@@ -711,7 +708,7 @@ templates:
       RESPONSE_OPERATIONS_UI_PORT: '80'
       SAMPLE_SERVICE_HOST: rm-sample-service-concourse-prod.apps.devtest.onsclofo.uk
       SAMPLE_SERVICE_PORT: '80'
-      SAMPLE_HOST: rm-sample-service-concourse-prod.apps.devtest.onsclofo.uk
+      SAMPLE_URL: http://rm-sample-service-concourse-prod.apps.devtest.onsclofo.uk
       SAMPLE_PORT: '80'
       SECURE_MESSAGE_URL: http://ras-secure-message-concourse-prod.apps.devtest.onsclofo.uk
       SECURE_MESSAGE_SERVICE_HOST: ras-secure-message-concourse-prod.apps.devtest.onsclofo.uk
@@ -914,7 +911,7 @@ resources:
     uri: "git@github.com:ONSdigital/rasrm-deploy-trigger"
     paths: ["preprod/*"]
     private_key: ((git_key))
-    
+
 - name: prod-deploy-trigger
   type: git
   source:
@@ -2735,7 +2732,7 @@ jobs:
     params:
       <<: *latest_security_user
       <<: *latest_service_endpoints_for_python
-      
+
 - name: preprod-trigger
   disable_manual_trigger: true
   plan:


### PR DESCRIPTION
This ticket involved changing the Sample Service for detecting duplicate sample_refs in sample uploads.
We also moved the backstage endpoint functionality to Response Operations UI.

New pattern for variables is like: SAMPLE_URL and not RM_SAMPLE_SERVICE_URL

The RM_SAMPLE_SERVICE_URL variants should be removed when ras-backstage is retired.