### PR TITLE
edit config for UAA and response operations

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -1105,8 +1105,8 @@ jobs:
         <<: *ci_security_user
         <<: *ci_service_endpoints_for_python
         RAS_SECURE_MESSAGING_JWT_SECRET: ((ci_jwt_secret))
-        UAA_CLIENT_ID: 'ras_backstage'
-        UAA_CLIENT_SECRET: ((ci_backstage_client_secret))
+        UAA_CLIENT_ID: 'response_operations'
+        UAA_CLIENT_SECRET: ((ci_response_operations_client_secret))
         UAA_SERVICE_URL: 'http://uaa-ci.apps.devtest.onsclofo.uk'
         USE_UAA: '1'
 
@@ -1973,8 +1973,8 @@ jobs:
         <<: *latest_security_user
         <<: *latest_service_endpoints_for_python
         RAS_SECURE_MESSAGING_JWT_SECRET: ((latest_jwt_secret))
-        UAA_CLIENT_ID: 'ras_backstage'
-        UAA_CLIENT_SECRET: ((latest_backstage_client_secret))
+        UAA_CLIENT_ID: 'response_operations'
+        UAA_CLIENT_SECRET: ((latest_response_operations_client_secret))
         UAA_SERVICE_URL: 'http://uaa-concourse-latest.apps.devtest.onsclofo.uk'
         USE_UAA: '1'
 
@@ -2850,8 +2850,8 @@ jobs:
         <<: *preprod_security_user
         <<: *preprod_service_endpoints_for_python
         RAS_SECURE_MESSAGING_JWT_SECRET: ((preprod_jwt_secret))
-        UAA_CLIENT_ID: 'ras_backstage'
-        UAA_CLIENT_SECRET: ((preprod_backstage_client_secret))
+        UAA_CLIENT_ID: 'response_operations'
+        UAA_CLIENT_SECRET: ((preprod_response_operations_client_secret))
         UAA_SERVICE_URL: 'http://uaa-concourse-preprod.apps.devtest.onsclofo.uk'
         USE_UAA: '1'
 
@@ -3738,8 +3738,8 @@ jobs:
         <<: *prod_security_user
         <<: *prod_service_endpoints_for_python
         RAS_SECURE_MESSAGING_JWT_SECRET: ((prod_jwt_secret))
-        UAA_CLIENT_ID: 'ras_backstage'
-        UAA_CLIENT_SECRET: ((prod_backstage_client_secret))
+        UAA_CLIENT_ID: 'response_operations'
+        UAA_CLIENT_SECRET: ((prod_response_operations_client_secret))
         UAA_SERVICE_URL: 'http://uaa-concourse-prod.apps.devtest.onsclofo.uk'
         USE_UAA: '1'
 

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -1304,6 +1304,8 @@ jobs:
         <<: *ci_service_endpoints_for_python
         RAS_SECURE_MESSAGING_JWT_SECRET: ((ci_jwt_secret))
         REDIS_SERVICE: ras-redis
+        UAA_CLIENT_ID: 'response_operations'
+        UAA_CLIENT_SECRET: ((ci_response_operations_client_secret))
 
 - name: rm-action-service-ci-deploy
   serial_groups: [rm-action-service-ci-deploy]
@@ -1762,7 +1764,7 @@ jobs:
         path: sh
         args:
         - './scripts/jenkins/add_client.sh'
-  - task: create-ras-backstage-client
+  - task: create-response_operations-client
     config:
       platform: linux
       image_resource:
@@ -1773,8 +1775,8 @@ jobs:
         - name: sdc-uaa-source
       params:
         SPACE: ci
-        CLIENT: ras_backstage
-        PASSWORD: ((ci_backstage_client_secret))
+        CLIENT: response_operations
+        PASSWORD: ((ci_response_operations_client_secret))
         ADMIN_SECRET: ((ci_uaa_admin_secret))
         UAA_URL: 'uaa-ci.apps.devtest.onsclofo.uk'
       run:
@@ -2160,6 +2162,8 @@ jobs:
         <<: *latest_service_endpoints_for_python
         RAS_SECURE_MESSAGING_JWT_SECRET: ((latest_jwt_secret))
         REDIS_SERVICE: ras-redis
+        UAA_CLIENT_ID: 'response_operations'
+        UAA_CLIENT_SECRET: ((latest_response_operations_client_secret))
 
 - name: rm-action-service-latest-deploy
   serial_groups: [rm-action-service-latest-deploy]
@@ -2598,7 +2602,7 @@ jobs:
         path: sh
         args:
         - './scripts/jenkins/add_client.sh'
-  - task: create-ras-backstage-client
+  - task: create-response_operations-client
     config:
       platform: linux
       image_resource:
@@ -2609,8 +2613,8 @@ jobs:
         - name: sdc-uaa-source
       params:
         SPACE: concourse-latest
-        CLIENT: ras_backstage
-        PASSWORD: ((latest_backstage_client_secret))
+        CLIENT: response_operations
+        PASSWORD: ((latest_response_operations_client_secret))
         ADMIN_SECRET: ((latest_uaa_admin_secret))
         UAA_URL: 'uaa-concourse-latest.apps.devtest.onsclofo.uk'
       run:
@@ -3040,6 +3044,8 @@ jobs:
         <<: *preprod_service_endpoints_for_python
         RAS_SECURE_MESSAGING_JWT_SECRET: ((preprod_jwt_secret))
         REDIS_SERVICE: ras-redis
+        UAA_CLIENT_ID: 'response_operations'
+        UAA_CLIENT_SECRET: ((preprod_response_operations_client_secret))
 
 - name: rm-action-service-preprod-deploy
   disable_manual_trigger: true
@@ -3488,7 +3494,7 @@ jobs:
         path: sh
         args:
         - './scripts/jenkins/add_client.sh'
-  - task: create-ras-backstage-client
+  - task: create-response_operations-client
     config:
       platform: linux
       image_resource:
@@ -3499,8 +3505,8 @@ jobs:
         - name: sdc-uaa-source
       params:
         SPACE: concourse-preprod
-        CLIENT: ras_backstage
-        PASSWORD: ((preprod_backstage_client_secret))
+        CLIENT: response_operations
+        PASSWORD: ((preprod_response_operations_client_secret))
         ADMIN_SECRET: ((preprod_uaa_admin_secret))
         UAA_URL: 'uaa-concourse-preprod.apps.devtest.onsclofo.uk'
       run:
@@ -3926,6 +3932,8 @@ jobs:
         <<: *prod_security_user
         RAS_SECURE_MESSAGING_JWT_SECRET: ((prod_jwt_secret))
         REDIS_SERVICE: ras-redis
+        UAA_CLIENT_ID: 'response_operations'
+        UAA_CLIENT_SECRET: ((prod_response_operations_client_secret))
 
 - name: rm-action-service-prod-deploy
   disable_manual_trigger: true
@@ -4374,7 +4382,7 @@ jobs:
         path: sh
         args:
         - './scripts/jenkins/add_client.sh'
-  - task: create-ras-backstage-client
+  - task: create-response_operations-client
     config:
       platform: linux
       image_resource:
@@ -4385,8 +4393,8 @@ jobs:
         - name: sdc-uaa-source
       params:
         SPACE: concourse-prod
-        CLIENT: ras_backstage
-        PASSWORD: ((prod_backstage_client_secret))
+        CLIENT: response_operations
+        PASSWORD: ((prod_response_operations_client_secret))
         ADMIN_SECRET: ((prod_uaa_admin_secret))
         UAA_URL: 'uaa-concourse-prod.apps.devtest.onsclofo.uk'
       run:

--- a/concourse/secrets.yml.example
+++ b/concourse/secrets.yml.example
@@ -30,7 +30,7 @@ ci_rabbitmq_amqp_collection_instrument:
 ci_rabbitmq_amqp_survey_response:
 ci_json_secret_keys:
 ci_secure_message_client_secret:
-ci_backstage_client_secret:
+ci_response_operations_client_secret:
 ci_collection_instrument_encryption_key:
 ci_enrolement_code_encryption_key:
 ci_uaa_private_key: |1-
@@ -55,7 +55,7 @@ latest_rabbitmq_amqp_collection_instrument:
 latest_rabbitmq_amqp_survey_response:
 latest_json_secret_keys:
 latest_secure_message_client_secret:
-latest_backstage_client_secret:
+latest_response_operations_client_secret:
 latest_collection_instrument_encryption_key:
 latest_enrolement_code_encryption_key:
 latest_uaa_private_key: |1-
@@ -80,7 +80,7 @@ preprod_rabbitmq_amqp_collection_instrument:
 preprod_rabbitmq_amqp_survey_response:
 preprod_json_secret_keys:
 preprod_secure_message_client_secret:
-preprod_backstage_client_secret:
+preprod_response_operations_client_secret:
 preprod_collection_instrument_encryption_key:
 preprod_enrolement_code_encryption_key:
 preprod_uaa_private_key: |1-
@@ -105,7 +105,7 @@ prod_rabbitmq_amqp_collection_instrument:
 prod_rabbitmq_amqp_survey_response:
 prod_json_secret_keys:
 prod_secure_message_client_secret:
-prod_backstage_client_secret:
+prod_response_operations_client_secret:
 prod_collection_instrument_encryption_key:
 prod_enrolement_code_encryption_key:
 prod_uaa_private_key: |1-


### PR DESCRIPTION
Config update for: https://github.com/ONSdigital/response-operations-ui/pull/163

Response operations should directly sign in with UAA.

https://trello.com/c/oodNbXR2/100-response-operations-ui-should-sign-in-directly-using-uaa-not-via-backstage