### PR TITLE
Split acceptance tests between rasrm and secure-message

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -795,7 +795,7 @@ resources:
   type: git
   source:
     uri: https://github.com/ONSdigital/ras-deploy.git
-    branch: secure-messaging
+    branch: master
 
 - name: ras-party-source
   type: git
@@ -837,7 +837,7 @@ resources:
   type: git
   source:
     uri: https://github.com/ONSdigital/django-oauth2-test.git
-    branch: create-user-script
+    branch: master
 
 - name: response-operations-ui-source
   type: git
@@ -923,7 +923,7 @@ resources:
   type: git
   source:
     uri: https://github.com/ONSdigital/rasrm-acceptance-tests.git
-    branch: secure-messaging
+    branch: master
 
 - name: cf-cli-resource-ci
   type: cf-cli-resource
@@ -1921,63 +1921,63 @@ jobs:
   plan:
   - get: ras-deploy
   - get: ci-teardown-timer
-    passed: [ci-rasrm-acceptance-tests]
     trigger: true
+    passed: *ci_all_services
   - get: rasrm-acceptance-tests-source
     trigger: true
   - get: ras-party-source
-    passed: [ci-rasrm-acceptance-tests]
+    passed: [ras-party-ci-deploy]
     trigger: true
   - get: ras-backstage-source
-    passed: [ci-rasrm-acceptance-tests]
+    passed: [ras-backstage-ci-deploy]
     trigger: true
   - get: ras-frontstage-source
-    passed: [ci-rasrm-acceptance-tests]
+    passed: [ras-frontstage-ci-deploy]
     trigger: true
   - get: ras-frontstage-api-source
-    passed: [ci-rasrm-acceptance-tests]
+    passed: [ras-frontstage-api-ci-deploy]
     trigger: true
   - get: django-oauth2-test-source
-    passed: [ci-rasrm-acceptance-tests]
+    passed: [django-oauth2-test-ci-deploy]
     trigger: true
   - get: response-operations-ui-source
-    passed: [ci-rasrm-acceptance-tests]
+    passed: [response-operations-ui-ci-deploy]
     trigger: true
   - get: ras-secure-message-source
-    passed: [ci-rasrm-acceptance-tests]
+    passed: [ras-secure-message-ci-deploy]
     trigger: true
   - get: ras-collection-instrument-source
-    passed: [ci-rasrm-acceptance-tests]
+    passed: [ras-collection-instrument-ci-deploy]
     trigger: true
   - get: rm-action-service-source
-    passed: [ci-rasrm-acceptance-tests]
+    passed: [rm-action-service-ci-deploy]
     trigger: true
   - get: rm-actionexporter-service-source
-    passed: [ci-rasrm-acceptance-tests]
+    passed: [rm-actionexporter-service-ci-deploy]
     trigger: true
   - get: rm-case-service-source
-    passed: [ci-rasrm-acceptance-tests]
+    passed: [rm-case-service-ci-deploy]
     trigger: true
   - get: rm-collection-exercise-service-source
-    passed: [ci-rasrm-acceptance-tests]
+    passed: [rm-collection-exercise-ci-deploy]
     trigger: true
   - get: iac-service-source
-    passed: [ci-rasrm-acceptance-tests]
+    passed: [iac-service-ci-deploy]
     trigger: true
   - get: rm-notify-gateway-source
-    passed: [ci-rasrm-acceptance-tests]
+    passed: [rm-notify-gateway-ci-deploy]
     trigger: true
   - get: rm-sample-service-source
-    passed: [ci-rasrm-acceptance-tests]
+    passed: [rm-sample-service-ci-deploy]
     trigger: true
   - get: rm-sdx-gateway-source
-    passed: [ci-rasrm-acceptance-tests]
+    passed: [rm-sdx-gateway-ci-deploy]
     trigger: true
   - get: rm-survey-service-source
-    passed: [ci-rasrm-acceptance-tests]
+    passed: [rm-survey-service-ci-deploy]
     trigger: true
   - get: sdc-uaa-source
-    passed: [ci-rasrm-acceptance-tests]
+    passed: [sdc-uaa-ci-deploy]
     trigger: true
   - task: get-cf-database-uris
     file: ras-deploy/tasks/get_database_uris.yml
@@ -2018,7 +2018,7 @@ jobs:
   plan:
   - get: ras-party-source
     trigger: true
-    passed: [ci-securemessage-acceptance-tests]
+    passed: [ci-rasrm-acceptance-tests, ci-securemessage-acceptance-tests]
   - put: create-database
     resource: cf-cli-resource-latest
     params:
@@ -2047,7 +2047,7 @@ jobs:
   plan:
   - get: ras-secure-message-source
     trigger: true
-    passed: [ci-securemessage-acceptance-tests]
+    passed: [ci-rasrm-acceptance-tests, ci-securemessage-acceptance-tests]
   - put: create-database
     resource: cf-cli-resource-latest
     params:
@@ -2083,7 +2083,7 @@ jobs:
   plan:
   - get: ras-backstage-source
     trigger: true
-    passed: [ci-securemessage-acceptance-tests]
+    passed: [ci-rasrm-acceptance-tests, ci-securemessage-acceptance-tests]
   - put: cf-resource-latest
     params:
       current_app_name: ras-backstage-concourse-latest
@@ -2103,7 +2103,7 @@ jobs:
   plan:
   - get: ras-collection-instrument-source
     trigger: true
-    passed: [ci-securemessage-acceptance-tests]
+    passed: [ci-rasrm-acceptance-tests, ci-securemessage-acceptance-tests]
   - get: ras-deploy
   - put: create-rm-rabbitmq
     resource: cf-cli-resource-latest
@@ -2150,7 +2150,7 @@ jobs:
   plan:
   - get: ras-frontstage-source
     trigger: true
-    passed: [ci-securemessage-acceptance-tests]
+    passed: [ci-rasrm-acceptance-tests, ci-securemessage-acceptance-tests]
   - <<: *latest_create_rm_redis
   - put: cf-resource-latest
     params:
@@ -2168,7 +2168,7 @@ jobs:
   plan:
   - get: ras-frontstage-api-source
     trigger: true
-    passed: [ci-securemessage-acceptance-tests]
+    passed: [ci-rasrm-acceptance-tests, ci-securemessage-acceptance-tests]
   - put: cf-resource-latest
     params:
       current_app_name: ras-frontstage-api-concourse-latest
@@ -2187,7 +2187,7 @@ jobs:
   plan:
   - get: django-oauth2-test-source
     trigger: true
-    passed: [ci-securemessage-acceptance-tests]
+    passed: [ci-rasrm-acceptance-tests, ci-securemessage-acceptance-tests]
   - get: ras-deploy
   - put: create-database
     resource: cf-cli-resource-latest
@@ -2262,7 +2262,7 @@ jobs:
   plan:
   - get: response-operations-ui-source
     trigger: true
-    passed: [ci-securemessage-acceptance-tests]
+    passed: [ci-rasrm-acceptance-tests, ci-securemessage-acceptance-tests]
   - put: create-redis
     resource: cf-cli-resource-latest
     params:
@@ -2288,7 +2288,7 @@ jobs:
   plan:
   - get: rm-action-service-source
     trigger: true
-    passed: [ci-securemessage-acceptance-tests]
+    passed: [ci-rasrm-acceptance-tests, ci-securemessage-acceptance-tests]
   - aggregate:
     - <<: *latest_create_rm_pg_db
     - <<: *latest_create_rm_redis
@@ -2328,7 +2328,7 @@ jobs:
   plan:
   - get: rm-actionexporter-service-source
     trigger: true
-    passed: [ci-securemessage-acceptance-tests]
+    passed: [ci-rasrm-acceptance-tests, ci-securemessage-acceptance-tests]
   - aggregate:
     - <<: *latest_create_rm_pg_db
     - <<: *latest_create_rm_redis
@@ -2372,7 +2372,7 @@ jobs:
   plan:
   - get: rm-case-service-source
     trigger: true
-    passed: [ci-securemessage-acceptance-tests]
+    passed: [ci-rasrm-acceptance-tests, ci-securemessage-acceptance-tests]
   - aggregate:
     - <<: *latest_create_rm_pg_db
     - <<: *latest_create_rm_redis
@@ -2412,7 +2412,7 @@ jobs:
   plan:
   - get: rm-collection-exercise-service-source
     trigger: true
-    passed: [ci-securemessage-acceptance-tests]
+    passed: [ci-rasrm-acceptance-tests, ci-securemessage-acceptance-tests]
   - aggregate:
     - <<: *latest_create_rm_pg_db
     - <<: *latest_create_rm_redis
@@ -2454,7 +2454,7 @@ jobs:
   plan:
   - get: iac-service-source
     trigger: true
-    passed: [ci-securemessage-acceptance-tests]
+    passed: [ci-rasrm-acceptance-tests, ci-securemessage-acceptance-tests]
   - aggregate:
     - <<: *latest_create_rm_pg_db
     - task: build
@@ -2492,7 +2492,7 @@ jobs:
   plan:
   - get: rm-notify-gateway-source
     trigger: true
-    passed: [ci-securemessage-acceptance-tests]
+    passed: [ci-rasrm-acceptance-tests, ci-securemessage-acceptance-tests]
   - aggregate:
     - <<: *latest_create_rm_pg_db
     - <<: *latest_create_rm_rabbitmq
@@ -2534,7 +2534,7 @@ jobs:
   plan:
   - get: rm-sample-service-source
     trigger: true
-    passed: [ci-securemessage-acceptance-tests]
+    passed: [ci-rasrm-acceptance-tests, ci-securemessage-acceptance-tests]
   - aggregate:
     - <<: *latest_create_rm_pg_db
     - <<: *latest_create_rm_redis
@@ -2580,7 +2580,7 @@ jobs:
   plan:
   - get: rm-sdx-gateway-source
     trigger: true
-    passed: [ci-securemessage-acceptance-tests]
+    passed: [ci-rasrm-acceptance-tests, ci-securemessage-acceptance-tests]
   - aggregate:
     - <<: *latest_create_rm_redis
     - <<: *latest_create_rm_rabbitmq
@@ -2618,7 +2618,7 @@ jobs:
   plan:
   - get: rm-survey-service-source
     trigger: true
-    passed: [ci-securemessage-acceptance-tests]
+    passed: [ci-rasrm-acceptance-tests, ci-securemessage-acceptance-tests]
   - aggregate:
     - <<: *latest_create_rm_pg_db
     - task: build
@@ -2656,7 +2656,7 @@ jobs:
   plan:
   - get: sdc-uaa-source
     trigger: true
-    passed: [ci-securemessage-acceptance-tests]
+    passed: [ci-rasrm-acceptance-tests, ci-securemessage-acceptance-tests]
   - task: build
     config:
       platform: linux

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -795,7 +795,7 @@ resources:
   type: git
   source:
     uri: https://github.com/ONSdigital/ras-deploy.git
-    branch: master
+    branch: secure-messaging
 
 - name: ras-party-source
   type: git
@@ -923,7 +923,7 @@ resources:
   type: git
   source:
     uri: https://github.com/ONSdigital/rasrm-acceptance-tests.git
-    branch: master
+    branch: secure-messaging
 
 - name: cf-cli-resource-ci
   type: cf-cli-resource
@@ -1820,7 +1820,7 @@ jobs:
         - './scripts/jenkins/add_user.sh'
 ### END CI DEPLOYMENTS
 
-- name: ci-acceptance-tests
+- name: ci-rasrm-acceptance-tests
   serial_groups: *ci_all_services
   plan:
   - get: ras-deploy
@@ -1891,16 +1891,125 @@ jobs:
       CLOUDFOUNDRY_PASSWORD: ((cloudfoundry_password))
       CLOUDFOUNDRY_ORG: rmras
       CLOUDFOUNDRY_SPACE: ci
-  - task: acceptance-test
+      MAKE_TARGET: rasrm_acceptance_tests
+  - task: acceptance-test-setup
     on_failure:
       put: notify
       params:
-        text: "Acceptance tests failed in CI space"
+        text: "Acceptance tests setup failed in CI space"
     privileged: true
     file: ras-deploy/tasks/rasrm-acceptance-tests/run_acceptance_tests.yml
     params:
       <<: *ci_security_user
       <<: *ci_service_endpoints_for_python
+      MAKE_TARGET: setup
+  - task: rasrm-acceptance-tests
+    on_failure:
+      put: notify
+      params:
+        text: "RASRM acceptance tests failed in CI space"
+    privileged: true
+    file: ras-deploy/tasks/rasrm-acceptance-tests/run_acceptance_tests.yml
+    params:
+      <<: *ci_security_user
+      <<: *ci_service_endpoints_for_python
+      MAKE_TARGET: rasrm_acceptance_tests
+
+- name: ci-securemessage-acceptance-tests
+  serial_groups:
+    *ci_all_services
+  plan:
+  - get: ras-deploy
+  - get: ci-teardown-timer
+    passed: [ci-rasrm-acceptance-tests]
+    trigger: true
+  - get: rasrm-acceptance-tests-source
+    trigger: true
+  - get: ras-party-source
+    passed: [ci-rasrm-acceptance-tests]
+    trigger: true
+  - get: ras-backstage-source
+    passed: [ci-rasrm-acceptance-tests]
+    trigger: true
+  - get: ras-frontstage-source
+    passed: [ci-rasrm-acceptance-tests]
+    trigger: true
+  - get: ras-frontstage-api-source
+    passed: [ci-rasrm-acceptance-tests]
+    trigger: true
+  - get: django-oauth2-test-source
+    passed: [ci-rasrm-acceptance-tests]
+    trigger: true
+  - get: response-operations-ui-source
+    passed: [ci-rasrm-acceptance-tests]
+    trigger: true
+  - get: ras-secure-message-source
+    passed: [ci-rasrm-acceptance-tests]
+    trigger: true
+  - get: ras-collection-instrument-source
+    passed: [ci-rasrm-acceptance-tests]
+    trigger: true
+  - get: rm-action-service-source
+    passed: [ci-rasrm-acceptance-tests]
+    trigger: true
+  - get: rm-actionexporter-service-source
+    passed: [ci-rasrm-acceptance-tests]
+    trigger: true
+  - get: rm-case-service-source
+    passed: [ci-rasrm-acceptance-tests]
+    trigger: true
+  - get: rm-collection-exercise-service-source
+    passed: [ci-rasrm-acceptance-tests]
+    trigger: true
+  - get: iac-service-source
+    passed: [ci-rasrm-acceptance-tests]
+    trigger: true
+  - get: rm-notify-gateway-source
+    passed: [ci-rasrm-acceptance-tests]
+    trigger: true
+  - get: rm-sample-service-source
+    passed: [ci-rasrm-acceptance-tests]
+    trigger: true
+  - get: rm-sdx-gateway-source
+    passed: [ci-rasrm-acceptance-tests]
+    trigger: true
+  - get: rm-survey-service-source
+    passed: [ci-rasrm-acceptance-tests]
+    trigger: true
+  - get: sdc-uaa-source
+    passed: [ci-rasrm-acceptance-tests]
+    trigger: true
+  - task: get-cf-database-uris
+    file: ras-deploy/tasks/get_database_uris.yml
+    params:
+      CLOUDFOUNDRY_API: ((cloudfoundry_api))
+      CLOUDFOUNDRY_EMAIL: ((cloudfoundry_email))
+      CLOUDFOUNDRY_PASSWORD: ((cloudfoundry_password))
+      CLOUDFOUNDRY_ORG: rmras
+      CLOUDFOUNDRY_SPACE: ci
+      MAKE_TARGET: rasrm_acceptance_tests
+  - task: acceptance-test-setup
+    on_failure:
+      put: notify
+      params:
+        text: "Acceptance tests setup failed in CI space"
+    privileged: true
+    file: ras-deploy/tasks/rasrm-acceptance-tests/run_acceptance_tests.yml
+    params:
+      <<: *ci_security_user
+      <<: *ci_service_endpoints_for_python
+      MAKE_TARGET: setup
+  - task: secure-messaging-acceptance-tests
+    on_failure:
+      put: notify
+      params:
+        text: "Secure Messaging acceptance tests failed in CI space"
+    privileged: true
+    file: ras-deploy/tasks/rasrm-acceptance-tests/run_acceptance_tests.yml
+    params:
+      <<: *ci_security_user
+      <<: *ci_service_endpoints_for_python
+      MAKE_TARGET: secure_messaging_acceptance_tests
 
 
 ### START latest SPACE DEPLOYMENTS
@@ -1909,7 +2018,7 @@ jobs:
   plan:
   - get: ras-party-source
     trigger: true
-    passed: [ci-acceptance-tests]
+    passed: [ci-securemessage-acceptance-tests]
   - put: create-database
     resource: cf-cli-resource-latest
     params:
@@ -1938,7 +2047,7 @@ jobs:
   plan:
   - get: ras-secure-message-source
     trigger: true
-    passed: [ci-acceptance-tests]
+    passed: [ci-securemessage-acceptance-tests]
   - put: create-database
     resource: cf-cli-resource-latest
     params:
@@ -1974,7 +2083,7 @@ jobs:
   plan:
   - get: ras-backstage-source
     trigger: true
-    passed: [ci-acceptance-tests]
+    passed: [ci-securemessage-acceptance-tests]
   - put: cf-resource-latest
     params:
       current_app_name: ras-backstage-concourse-latest
@@ -1994,7 +2103,7 @@ jobs:
   plan:
   - get: ras-collection-instrument-source
     trigger: true
-    passed: [ci-acceptance-tests]
+    passed: [ci-securemessage-acceptance-tests]
   - get: ras-deploy
   - put: create-rm-rabbitmq
     resource: cf-cli-resource-latest
@@ -2041,7 +2150,7 @@ jobs:
   plan:
   - get: ras-frontstage-source
     trigger: true
-    passed: [ci-acceptance-tests]
+    passed: [ci-securemessage-acceptance-tests]
   - <<: *latest_create_rm_redis
   - put: cf-resource-latest
     params:
@@ -2059,7 +2168,7 @@ jobs:
   plan:
   - get: ras-frontstage-api-source
     trigger: true
-    passed: [ci-acceptance-tests]
+    passed: [ci-securemessage-acceptance-tests]
   - put: cf-resource-latest
     params:
       current_app_name: ras-frontstage-api-concourse-latest
@@ -2078,7 +2187,7 @@ jobs:
   plan:
   - get: django-oauth2-test-source
     trigger: true
-    passed: [ci-acceptance-tests]
+    passed: [ci-securemessage-acceptance-tests]
   - get: ras-deploy
   - put: create-database
     resource: cf-cli-resource-latest
@@ -2153,7 +2262,7 @@ jobs:
   plan:
   - get: response-operations-ui-source
     trigger: true
-    passed: [ci-acceptance-tests]
+    passed: [ci-securemessage-acceptance-tests]
   - put: create-redis
     resource: cf-cli-resource-latest
     params:
@@ -2179,7 +2288,7 @@ jobs:
   plan:
   - get: rm-action-service-source
     trigger: true
-    passed: [ci-acceptance-tests]
+    passed: [ci-securemessage-acceptance-tests]
   - aggregate:
     - <<: *latest_create_rm_pg_db
     - <<: *latest_create_rm_redis
@@ -2219,7 +2328,7 @@ jobs:
   plan:
   - get: rm-actionexporter-service-source
     trigger: true
-    passed: [ci-acceptance-tests]
+    passed: [ci-securemessage-acceptance-tests]
   - aggregate:
     - <<: *latest_create_rm_pg_db
     - <<: *latest_create_rm_redis
@@ -2263,7 +2372,7 @@ jobs:
   plan:
   - get: rm-case-service-source
     trigger: true
-    passed: [ci-acceptance-tests]
+    passed: [ci-securemessage-acceptance-tests]
   - aggregate:
     - <<: *latest_create_rm_pg_db
     - <<: *latest_create_rm_redis
@@ -2303,7 +2412,7 @@ jobs:
   plan:
   - get: rm-collection-exercise-service-source
     trigger: true
-    passed: [ci-acceptance-tests]
+    passed: [ci-securemessage-acceptance-tests]
   - aggregate:
     - <<: *latest_create_rm_pg_db
     - <<: *latest_create_rm_redis
@@ -2345,7 +2454,7 @@ jobs:
   plan:
   - get: iac-service-source
     trigger: true
-    passed: [ci-acceptance-tests]
+    passed: [ci-securemessage-acceptance-tests]
   - aggregate:
     - <<: *latest_create_rm_pg_db
     - task: build
@@ -2383,7 +2492,7 @@ jobs:
   plan:
   - get: rm-notify-gateway-source
     trigger: true
-    passed: [ci-acceptance-tests]
+    passed: [ci-securemessage-acceptance-tests]
   - aggregate:
     - <<: *latest_create_rm_pg_db
     - <<: *latest_create_rm_rabbitmq
@@ -2425,7 +2534,7 @@ jobs:
   plan:
   - get: rm-sample-service-source
     trigger: true
-    passed: [ci-acceptance-tests]
+    passed: [ci-securemessage-acceptance-tests]
   - aggregate:
     - <<: *latest_create_rm_pg_db
     - <<: *latest_create_rm_redis
@@ -2471,7 +2580,7 @@ jobs:
   plan:
   - get: rm-sdx-gateway-source
     trigger: true
-    passed: [ci-acceptance-tests]
+    passed: [ci-securemessage-acceptance-tests]
   - aggregate:
     - <<: *latest_create_rm_redis
     - <<: *latest_create_rm_rabbitmq
@@ -2509,7 +2618,7 @@ jobs:
   plan:
   - get: rm-survey-service-source
     trigger: true
-    passed: [ci-acceptance-tests]
+    passed: [ci-securemessage-acceptance-tests]
   - aggregate:
     - <<: *latest_create_rm_pg_db
     - task: build
@@ -2547,7 +2656,7 @@ jobs:
   plan:
   - get: sdc-uaa-source
     trigger: true
-    passed: [ci-acceptance-tests]
+    passed: [ci-securemessage-acceptance-tests]
   - task: build
     config:
       platform: linux
@@ -2662,7 +2771,7 @@ jobs:
   - get: ras-deploy
   - get: rasrm-acceptance-tests-source
     trigger: true
-    passed: [ci-acceptance-tests]
+    passed: [ci-rasrm-acceptance-tests,ci-securemessage-acceptance-tests]
   - get: ras-party-source
     passed: [ras-party-latest-deploy]
     trigger: true
@@ -2732,7 +2841,7 @@ jobs:
     params:
       <<: *latest_security_user
       <<: *latest_service_endpoints_for_python
-
+      MAKE_TARGET: acceptance_tests
 - name: preprod-trigger
   disable_manual_trigger: true
   plan:

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -35,7 +35,7 @@ templates:
       SURVEY_USERNAME: ((ci_security_user_name))
       SURVEY_PASSWORD: ((ci_security_user_password))
       SAMPLE_USERNAME: ((ci_security_user_name))
-      SAMPLE_PASWORD: ((ci_security_user_password))
+      SAMPLE_PASSWORD: ((ci_security_user_password))
 
     all_services: &ci_all_services
     - ras-party-ci-deploy
@@ -1891,7 +1891,6 @@ jobs:
       CLOUDFOUNDRY_PASSWORD: ((cloudfoundry_password))
       CLOUDFOUNDRY_ORG: rmras
       CLOUDFOUNDRY_SPACE: ci
-      MAKE_TARGET: rasrm_acceptance_tests
   - task: acceptance-test-setup
     on_failure:
       put: notify
@@ -1987,7 +1986,6 @@ jobs:
       CLOUDFOUNDRY_PASSWORD: ((cloudfoundry_password))
       CLOUDFOUNDRY_ORG: rmras
       CLOUDFOUNDRY_SPACE: ci
-      MAKE_TARGET: rasrm_acceptance_tests
   - task: acceptance-test-setup
     on_failure:
       put: notify

--- a/scripts/rasrm-acceptance-tests/run_acceptance_tests.sh
+++ b/scripts/rasrm-acceptance-tests/run_acceptance_tests.sh
@@ -7,4 +7,4 @@ source cf-database-env-vars/setenv.sh
 cd rasrm-acceptance-tests-source
 
 pipenv install --dev
-make BEHAVE_FORMAT=pretty setup wait_for_services acceptance_tests
+make BEHAVE_FORMAT=pretty "${MAKE_TARGET}"


### PR DESCRIPTION
This splits the ci-rasrm-acceptance-tests into 2 jobs; one to run the rasrm tests and the other to run just the secure-messaging tests.  The secure-messaging tests are all tagged and the rasrm job runs all tests that do not have a @secure-messaging tag.

To test:

- Fly the pipeline.  
- There are dependencies where both ci acceptance test jobs cannot run at the same time and neither can run if a ci service is being deployed.