### PR TITLE
Point django deployment to master

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -837,7 +837,7 @@ resources:
   type: git
   source:
     uri: https://github.com/ONSdigital/django-oauth2-test.git
-    branch: create-user-script
+    branch: master
 
 - name: response-operations-ui-source
   type: git


### PR DESCRIPTION
# Background
The django app was being built off of a branch whilst some changes were
waiting to be merged.
https://github.com/ONSdigital/django-oauth2-test/pull/35 has now been
merged so updating to point to master.

# How to test
Fly the pipeline and run CI tests