### PR TITLE
Change teardown time to 6AM

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -916,7 +916,7 @@ resources:
 - name: ci-teardown-timer
   type: time
   source:
-    interval: 24h
+    start: 6AM
 
 - name: cf-cli-resource-latest
   type: cf-cli-resource


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The teardown timer was set to kick off around 2:30pm. This is not
convenient as it's during work hours and can

* Block commits going through the pipeline whilst tearing down
* Interrupt any debugging that is going on

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Changed the teardown timer to start at 6AM

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Deploy the pipeline and wait until 6AM to check it kicks off 😅 
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://github.com/concourse/time-resource#source-configuration