### PR TITLE
Adding stop configuration

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -917,6 +917,7 @@ resources:
   type: time
   source:
     start: 6AM
+    stop: 7AM
 
 - name: cf-cli-resource-latest
   type: cf-cli-resource


### PR DESCRIPTION
# Motivation and Context
Previously added start configuration to fix the teardown of the CI environment to 6AM but it's failing due to it being misconfigured. Start configuration requires a stop variable to be set as described by the documentation https://github.com/concourse/time-resource#trigger-once-within-time-range.

# What has changed
Adding mandatory stop configuration

# How to test?
Deploy pipeline and wait until 6AM for the job to kick off

# Links
https://github.com/ONSdigital/ras-deploy/pull/23