### PR TITLE
Skip integration tests for actionexporter

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -1383,7 +1383,7 @@ jobs:
     - <<: *ci_create_rm_redis
     - <<: *ci_create_rm_rabbitmq
     - task: build
-      file: ras-deploy/tasks/build-java-service.yml
+      file: ras-deploy/tasks/build-java-service-skip-IT.yml
       input_mapping: { repository-name: rm-collection-exercise-service-source }
   - put: cf-resource-ci
     params:
@@ -2190,7 +2190,7 @@ jobs:
     - <<: *latest_create_rm_redis
     - <<: *latest_create_rm_rabbitmq
     - task: build
-      file: ras-deploy/tasks/build-java-service.yml
+      file: ras-deploy/tasks/build-java-service-skip-IT.yml
       input_mapping: { repository-name: rm-collection-exercise-service-source }
   - put: cf-resource-latest
     params:
@@ -2929,7 +2929,7 @@ disabled-jobs:
     - <<: *preprod_create_rm_redis
     - <<: *preprod_create_rm_rabbitmq
     - task: build
-      file: ras-deploy/tasks/build-java-service.yml
+      file: ras-deploy/tasks/build-java-service-skip-IT.yml
       input_mapping: { repository-name: rm-collection-exercise-service-source }
   - put: cf-resource-preprod
     params:
@@ -3668,7 +3668,7 @@ disabled-jobs:
     - <<: *prod_create_rm_redis
     - <<: *prod_create_rm_rabbitmq
     - task: build
-      file: ras-deploy/tasks/build-java-service.yml
+      file: ras-deploy/tasks/build-java-service-skip-IT.yml
       input_mapping: { repository-name: rm-collection-exercise-service-source }
   - put: cf-resource-prod
     params:

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -1327,8 +1327,25 @@ jobs:
     - <<: *ci_create_rm_redis
     - <<: *ci_create_rm_rabbitmq
     - task: build
-      file: ras-deploy/tasks/build-java-service.yml
-      input_mapping: { repository-name: rm-actionexporter-service-source }
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: maven
+            tag: 3.3.9-jdk-8
+        inputs:
+          - name: rm-actionexporter-service-source
+        outputs:
+          - name: target
+            path: target
+        run:
+          path: sh
+          args:
+          - -exc
+          - |
+            mvn --settings rm-actionexporter-service-source/.maven.settings.xml install -Ddockerfile.skip -Ddocker.skip -DskipITs -f rm-actionexporter-service-source/pom.xml
+            cp -r rm-actionexporter-service-source/target/ .
   - put: cf-resource-ci
     params:
       current_app_name: rm-actionexporter-service-ci
@@ -2154,8 +2171,25 @@ jobs:
     - <<: *latest_create_rm_redis
     - <<: *latest_create_rm_rabbitmq
     - task: build
-      file: ras-deploy/tasks/build-java-service.yml
-      input_mapping: { repository-name: rm-actionexporter-service-source }
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: maven
+            tag: 3.3.9-jdk-8
+        inputs:
+          - name: rm-actionexporter-service-source
+        outputs:
+          - name: target
+            path: target
+        run:
+          path: sh
+          args:
+          - -exc
+          - |
+            mvn --settings rm-actionexporter-service-source/.maven.settings.xml install -Ddockerfile.skip -Ddocker.skip -DskipITs -f rm-actionexporter-service-source/pom.xml
+            cp -r rm-actionexporter-service-source/target/ .
   - put: cf-resource-latest
     params:
       current_app_name: rm-actionexporter-service-concourse-latest
@@ -2907,8 +2941,25 @@ disabled-jobs:
     - <<: *preprod_create_rm_redis
     - <<: *preprod_create_rm_rabbitmq
     - task: build
-      file: ras-deploy/tasks/build-java-service.yml
-      input_mapping: { repository-name: rm-actionexporter-service-source }
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: maven
+            tag: 3.3.9-jdk-8
+        inputs:
+          - name: rm-actionexporter-service-source
+        outputs:
+          - name: target
+            path: target
+        run:
+          path: sh
+          args:
+          - -exc
+          - |
+            mvn --settings rm-actionexporter-service-source/.maven.settings.xml install -Ddockerfile.skip -Ddocker.skip -DskipITs -f rm-actionexporter-service-source/pom.xml
+            cp -r rm-actionexporter-service-source/target/ .
   - put: cf-resource-preprod
     params:
       current_app_name: rm-actionexporter-service-concourse-preprod
@@ -3662,8 +3713,25 @@ disabled-jobs:
     - <<: *prod_create_rm_redis
     - <<: *prod_create_rm_rabbitmq
     - task: build
-      file: ras-deploy/tasks/build-java-service.yml
-      input_mapping: { repository-name: rm-actionexporter-service-source }
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: maven
+            tag: 3.3.9-jdk-8
+        inputs:
+          - name: rm-actionexporter-service-source
+        outputs:
+          - name: target
+            path: target
+        run:
+          path: sh
+          args:
+          - -exc
+          - |
+            mvn --settings rm-actionexporter-service-source/.maven.settings.xml install -Ddockerfile.skip -Ddocker.skip -DskipITs -f rm-actionexporter-service-source/pom.xml
+            cp -r rm-actionexporter-service-source/target/ .
   - put: cf-resource-prod
     params:
       current_app_name: rm-actionexporter-service-concourse-prod

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -1327,25 +1327,8 @@ jobs:
     - <<: *ci_create_rm_redis
     - <<: *ci_create_rm_rabbitmq
     - task: build
-      config:
-        platform: linux
-        image_resource:
-          type: docker-image
-          source:
-            repository: maven
-            tag: 3.3.9-jdk-8
-        inputs:
-          - name: rm-actionexporter-service-source
-        outputs:
-          - name: target
-            path: target
-        run:
-          path: sh
-          args:
-          - -exc
-          - |
-            mvn --settings rm-actionexporter-service-source/.maven.settings.xml install -Ddockerfile.skip -Ddocker.skip -DskipITs -f rm-actionexporter-service-source/pom.xml
-            cp -r rm-actionexporter-service-source/target/ .
+      file: ras-deploy/tasks/build-java-service-skip-IT.yml
+      input_mapping: { repository-name: rm-actionexporter-service-source }
   - put: cf-resource-ci
     params:
       current_app_name: rm-actionexporter-service-ci
@@ -1479,25 +1462,8 @@ jobs:
     - <<: *ci_create_rm_redis
     - <<: *ci_create_rm_rabbitmq
     - task: build
-      config:
-        platform: linux
-        image_resource:
-          type: docker-image
-          source:
-            repository: maven
-            tag: 3.3.9-jdk-8
-        inputs:
-          - name: rm-sample-service-source
-        outputs:
-          - name: target
-            path: target
-        run:
-          path: sh
-          args:
-          - -exc
-          - |
-            mvn --settings rm-sample-service-source/.maven.settings.xml install -Ddockerfile.skip -Ddocker.skip -DskipITs -f rm-sample-service-source/pom.xml
-            cp -r rm-sample-service-source/target/ .
+      file: ras-deploy/tasks/build-java-service-skip-IT.yml
+      input_mapping: { repository-name: rm-sample-service-source }
   - put: cf-resource-ci
     params:
       current_app_name: rm-sample-service-ci
@@ -2171,25 +2137,8 @@ jobs:
     - <<: *latest_create_rm_redis
     - <<: *latest_create_rm_rabbitmq
     - task: build
-      config:
-        platform: linux
-        image_resource:
-          type: docker-image
-          source:
-            repository: maven
-            tag: 3.3.9-jdk-8
-        inputs:
-          - name: rm-actionexporter-service-source
-        outputs:
-          - name: target
-            path: target
-        run:
-          path: sh
-          args:
-          - -exc
-          - |
-            mvn --settings rm-actionexporter-service-source/.maven.settings.xml install -Ddockerfile.skip -Ddocker.skip -DskipITs -f rm-actionexporter-service-source/pom.xml
-            cp -r rm-actionexporter-service-source/target/ .
+      file: ras-deploy/tasks/build-java-service-skip-IT.yml
+      input_mapping: { repository-name: rm-actionexporter-service-source }
   - put: cf-resource-latest
     params:
       current_app_name: rm-actionexporter-service-concourse-latest
@@ -2313,25 +2262,8 @@ jobs:
     - <<: *latest_create_rm_redis
     - <<: *latest_create_rm_rabbitmq
     - task: build
-      config:
-        platform: linux
-        image_resource:
-          type: docker-image
-          source:
-            repository: maven
-            tag: 3.3.9-jdk-8
-        inputs:
-          - name: rm-sample-service-source
-        outputs:
-          - name: target
-            path: target
-        run:
-          path: sh
-          args:
-          - -exc
-          - |
-            mvn --settings rm-sample-service-source/.maven.settings.xml install -Ddockerfile.skip -Ddocker.skip -DskipITs -f rm-sample-service-source/pom.xml
-            cp -r rm-sample-service-source/target/ .
+      file: ras-deploy/tasks/build-java-service-skip-IT.yml
+      input_mapping: { repository-name: rm-sample-service-source }
   - put: cf-resource-latest
     params:
       current_app_name: rm-sample-service-concourse-latest
@@ -2941,25 +2873,8 @@ disabled-jobs:
     - <<: *preprod_create_rm_redis
     - <<: *preprod_create_rm_rabbitmq
     - task: build
-      config:
-        platform: linux
-        image_resource:
-          type: docker-image
-          source:
-            repository: maven
-            tag: 3.3.9-jdk-8
-        inputs:
-          - name: rm-actionexporter-service-source
-        outputs:
-          - name: target
-            path: target
-        run:
-          path: sh
-          args:
-          - -exc
-          - |
-            mvn --settings rm-actionexporter-service-source/.maven.settings.xml install -Ddockerfile.skip -Ddocker.skip -DskipITs -f rm-actionexporter-service-source/pom.xml
-            cp -r rm-actionexporter-service-source/target/ .
+      file: ras-deploy/tasks/build-java-service-skip-IT.yml
+      input_mapping: { repository-name: rm-actionexporter-service-source }
   - put: cf-resource-preprod
     params:
       current_app_name: rm-actionexporter-service-concourse-preprod
@@ -3088,25 +3003,8 @@ disabled-jobs:
     - <<: *preprod_create_rm_redis
     - <<: *preprod_create_rm_rabbitmq
     - task: build
-      config:
-        platform: linux
-        image_resource:
-          type: docker-image
-          source:
-            repository: maven
-            tag: 3.3.9-jdk-8
-        inputs:
-          - name: rm-sample-service-source
-        outputs:
-          - name: target
-            path: target
-        run:
-          path: sh
-          args:
-          - -exc
-          - |
-            mvn --settings rm-sample-service-source/.maven.settings.xml install -Ddockerfile.skip -Ddocker.skip -DskipITs -f rm-sample-service-source/pom.xml
-            cp -r rm-sample-service-source/target/ .
+      file: ras-deploy/tasks/build-java-service-skip-IT.yml
+      input_mapping: { repository-name: rm-sample-service-source }
   - put: cf-resource-preprod
     params:
       current_app_name: rm-sample-service-concourse-preprod
@@ -3713,25 +3611,8 @@ disabled-jobs:
     - <<: *prod_create_rm_redis
     - <<: *prod_create_rm_rabbitmq
     - task: build
-      config:
-        platform: linux
-        image_resource:
-          type: docker-image
-          source:
-            repository: maven
-            tag: 3.3.9-jdk-8
-        inputs:
-          - name: rm-actionexporter-service-source
-        outputs:
-          - name: target
-            path: target
-        run:
-          path: sh
-          args:
-          - -exc
-          - |
-            mvn --settings rm-actionexporter-service-source/.maven.settings.xml install -Ddockerfile.skip -Ddocker.skip -DskipITs -f rm-actionexporter-service-source/pom.xml
-            cp -r rm-actionexporter-service-source/target/ .
+      file: ras-deploy/tasks/build-java-service-skip-IT.yml
+      input_mapping: { repository-name: rm-actionexporter-service-source }
   - put: cf-resource-prod
     params:
       current_app_name: rm-actionexporter-service-concourse-prod
@@ -3860,25 +3741,8 @@ disabled-jobs:
     - <<: *prod_create_rm_redis
     - <<: *prod_create_rm_rabbitmq
     - task: build
-      config:
-        platform: linux
-        image_resource:
-          type: docker-image
-          source:
-            repository: maven
-            tag: 3.3.9-jdk-8
-        inputs:
-          - name: rm-sample-service-source
-        outputs:
-          - name: target
-            path: target
-        run:
-          path: sh
-          args:
-          - -exc
-          - |
-            mvn --settings rm-sample-service-source/.maven.settings.xml install -Ddockerfile.skip -Ddocker.skip -DskipITs -f rm-sample-service-source/pom.xml
-            cp -r rm-sample-service-source/target/ .
+      file: ras-deploy/tasks/build-java-service-skip-IT.yml
+      input_mapping: { repository-name: rm-sample-service-source }
   - put: cf-resource-prod
     params:
       current_app_name: rm-sample-service-concourse-prod

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -1457,6 +1457,7 @@ jobs:
   - get: ci-teardown-timer
     trigger: true
     passed: [ci-teardown]
+  - get: ras-deploy
   - aggregate:
     - <<: *ci_create_rm_pg_db
     - <<: *ci_create_rm_redis
@@ -2257,6 +2258,7 @@ jobs:
   - get: rm-sample-service-source
     trigger: true
     passed: [ci-rasrm-acceptance-tests, ci-securemessage-acceptance-tests]
+  - get: ras-deploy
   - aggregate:
     - <<: *latest_create_rm_pg_db
     - <<: *latest_create_rm_redis
@@ -2998,6 +3000,7 @@ disabled-jobs:
   - get: rm-sample-service-source
     trigger: true
     passed: [preprod-trigger]
+  - get: ras-deploy
   - aggregate:
     - <<: *preprod_create_rm_pg_db
     - <<: *preprod_create_rm_redis
@@ -3736,6 +3739,7 @@ disabled-jobs:
   - get: rm-sample-service-source
     trigger: true
     passed: [prod-trigger]
+  - get: ras-deploy
   - aggregate:
     - <<: *prod_create_rm_pg_db
     - <<: *prod_create_rm_redis

--- a/pipelines/loadtest.yml
+++ b/pipelines/loadtest.yml
@@ -682,7 +682,7 @@ jobs:
     - <<: *loadtest_create_rm_redis
     - <<: *loadtest_create_rm_rabbitmq
     - task: build
-      file: ras-deploy/tasks/build-java-service.yml
+      file: ras-deploy/tasks/build-java-service-skip-IT.yml
       input_mapping: { repository-name: rm-collection-exercise-service-source }
   - put: cf-resource-((loadtest_cloudfoundry_space))
     params:

--- a/pipelines/loadtest.yml
+++ b/pipelines/loadtest.yml
@@ -633,8 +633,8 @@ jobs:
     - <<: *loadtest_create_rm_pg_db
     - <<: *loadtest_create_rm_redis
     - <<: *loadtest_create_rm_rabbitmq
-    - task: build 
-      file: ras-deploy/tasks/build-java-service.yml
+    - task: build
+      file: ras-deploy/tasks/build-java-service-skip-IT.yml
       input_mapping: { repository-name: rm-actionexporter-service-source }
   - put: cf-resource-((loadtest_cloudfoundry_space))
     params:
@@ -750,25 +750,8 @@ jobs:
     - <<: *loadtest_create_rm_redis
     - <<: *loadtest_create_rm_rabbitmq
     - task: build
-      config:
-        platform: linux
-        image_resource:
-          type: docker-image
-          source:
-            repository: maven
-            tag: 3.3.9-jdk-8
-        inputs:
-          - name: rm-sample-service-source
-        outputs:
-          - name: target
-            path: target
-        run:
-          path: sh
-          args:
-          - -exc
-          - |
-            mvn --settings rm-sample-service-source/.maven.settings.xml install -Ddockerfile.skip -Ddocker.skip -DskipITs -f rm-sample-service-source/pom.xml
-            cp -r rm-sample-service-source/target/ .
+      file: ras-deploy/tasks/build-java-service-skip-IT.yml
+      input_mapping: { repository-name: rm-sample-service-source }
   - put: cf-resource-((loadtest_cloudfoundry_space))
     params:
       current_app_name: rm-sample-service-((loadtest_cloudfoundry_space))

--- a/tasks/build-java-service-skip-IT.yml
+++ b/tasks/build-java-service-skip-IT.yml
@@ -1,0 +1,23 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: maven
+    tag: 3.3.9-jdk-8
+
+inputs:
+  - name: repository-name
+
+outputs:
+  - name: target
+    path: target
+
+run:
+  path: sh
+  args:
+  - -exc
+  - |
+    mvn --settings repository-name/.maven.settings.xml install -Ddockerfile.skip -Ddocker.skip -DskipITs -f repository-name/pom.xml
+    cp -r repository-name/target/ .


### PR DESCRIPTION
# Motivation and Context
Action exporter now has some integration tests that run up docker
containers to test in integration with other services. Concourse doesn't
support running like this so we are skipping the ITs for now.

# What has changed
Adding maven arguments to skip integration tests

# How to test?
Run `mvn --settings rm-actionexporter-service-source/.maven.settings.xml install -Ddockerfile.skip -Ddocker.skip -DskipITs -f rm-actionexporter-service-source/pom.xml` and confirm tests do not run

# Links
http://dmp.fabric8.io/#global-configuration
