### PR TITLE
Add URL to Slack message for failing builds

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -1748,7 +1748,9 @@ jobs:
     on_failure:
       put: notify
       params:
-        text: "Acceptance tests setup failed in CI space"
+        text:  |
+          Acceptance tests setup failed in CI space.  Check the build:
+          $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
     privileged: true
     file: ras-deploy/tasks/rasrm-acceptance-tests/run_acceptance_tests.yml
     params:
@@ -1759,7 +1761,9 @@ jobs:
     on_failure:
       put: notify
       params:
-        text: "RASRM acceptance tests failed in CI space"
+        text:  |
+          RASRM acceptance tests failed in CI space.  Check the build:
+          $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
     privileged: true
     file: ras-deploy/tasks/rasrm-acceptance-tests/run_acceptance_tests.yml
     params:
@@ -1840,7 +1844,9 @@ jobs:
     on_failure:
       put: notify
       params:
-        text: "Acceptance tests setup failed in CI space"
+        text:  |
+          Acceptance tests setup failed in CI space.  Check the build:
+          $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
     privileged: true
     file: ras-deploy/tasks/rasrm-acceptance-tests/run_acceptance_tests.yml
     params:
@@ -1851,7 +1857,9 @@ jobs:
     on_failure:
       put: notify
       params:
-        text: "Secure Messaging acceptance tests failed in CI space"
+        text:  |
+          Secure Messaging acceptance tests failed in CI space.  Check the build:
+          $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
     privileged: true
     file: ras-deploy/tasks/rasrm-acceptance-tests/run_acceptance_tests.yml
     params:


### PR DESCRIPTION
# Motivation and Context
Current Slack messages state that acceptance tests have failed but give no info into what has failed (ie build number).  

# What has changed
Added the URL of the failing build in the Slack messages so that devs can go directly to the failing tests to investigate any issues.

# How to test?
Confirm that the URL of the failing acceptance tests appears in the Slack message and that the link works.