### PR TITLE
Get ras-deploy resource on sdx-gateway-ci

### DIFF
--- a/pipelines/deployment.yml
+++ b/pipelines/deployment.yml
@@ -1489,6 +1489,7 @@ jobs:
   - get: ci-teardown-timer
     trigger: true
     passed: [ci-teardown]
+  - get: ras-deploy
   - aggregate:
     - <<: *ci_create_rm_redis
     - <<: *ci_create_rm_rabbitmq


### PR DESCRIPTION
# Motivation and Context
Concourse deployment for sdx-gateway-ci-deploy was failing with the
message `unknown artifact source: ras-deploy`. This is because it's
trying to use a resource from the ras-deploy repo without pulling it.

This change gets the ras-deploy resource before using it.

# What has changed
Get ras-deploy in sdx-gateway-ci-deploy

# How to test?
Fly pipeline and check the sdx-gateway-ci-deploy build passes
