### PR TITLE
Skip http wait plugin

### DIFF
--- a/tasks/build-java-service-skip-IT.yml
+++ b/tasks/build-java-service-skip-IT.yml
@@ -19,5 +19,5 @@ run:
   args:
   - -exc
   - |
-    mvn --settings repository-name/.maven.settings.xml install -Ddockerfile.skip -Ddocker.skip -DskipITs -f repository-name/pom.xml
+    mvn --settings repository-name/.maven.settings.xml install -Ddockerfile.skip -Ddocker.skip -DskipITs -Dhttp.wait.skip -f repository-name/pom.xml
     cp -r repository-name/target/ .


### PR DESCRIPTION
# Motivation and Context
The http wait plugin is used to wait for services to be up and running
before running the integration tests. If the integration tests tests are
skipped then we don't want to wait for the service to be up.

# What has changed
* Add `-Dhttp.wait.skip` to skip http wait

# How to test?
* Run `mvn --settings .maven.settings.xml install -Ddockerfile.skip -Ddocker.skip -DskipITs -Dhttp.wait.skip` in the rm-collection-exercise-service
* Deploy this version of the pipeline and see rm-collection-exercise-service pass
	1. Change the branch for ras-deploy resource to `skip-wait-for-service` (https://github.com/ONSdigital/ras-deploy/blob/master/pipelines/deployment.yml#L786)
	1. Fly the pipeline

# Links
https://github.com/ONSdigital/rm-collection-exercise-service/pull/77
https://github.com/tsundberg/maven-wait-plugin/pull/1
