### PR TITLE
Lower sample service logging

### DIFF
--- a/pipelines/deployment.yml
+++ b/pipelines/deployment.yml
@@ -1481,6 +1481,8 @@ jobs:
         sftp_password: ((sample_sftp_password))
         sftp_port: '22'
         sftp_username: ((sample_sftp_username))
+        LOGGING_LEVEL_uk.gov.ons.ctp.response.sample.scheduled.distribution: WARN
+        LOGGING_LEVEL_uk.gov.ons.ctp.common.distributed: INFO
 
 - name: rm-sdx-gateway-ci-deploy
   serial_groups: [rm-sdx-gateway-ci-deploy]


### PR DESCRIPTION
# Motivation and Context
Sample service has a class that polls every 1s in the CI space that
generates a lot of logs. This makes it hard to see any logs of interest
through the other verbose logs.

It will cut out the example below every 1s

```

   2018-06-29T12:26:48.36+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,361","service":"samplesvc","level":"INFO","event":"SampleUnitDistributor is in the house"}
   2018-06-29T12:26:48.36+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,366","service":"samplesvc","level":"DEBUG","event":"retrieve sample units excluding []"}
   2018-06-29T12:26:48.36+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,365","service":"samplesvc","level":"DEBUG","event":"Succeeded to obtain lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.36+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,364","service":"samplesvc","level":"DEBUG","event":"Attempting to obtain lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.36+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,368","service":"samplesvc","level":"DEBUG","event":"Attempting to relinquish lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.37+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,372","service":"samplesvc","level":"DEBUG","event":"retrieve sample units excluding []"}
   2018-06-29T12:26:48.37+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,375","service":"samplesvc","level":"DEBUG","event":"Succeeded to relinquish lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.37+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,370","service":"samplesvc","level":"DEBUG","event":"Attempting to obtain lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.37+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,371","service":"samplesvc","level":"DEBUG","event":"Succeeded to obtain lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.37+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,374","service":"samplesvc","level":"DEBUG","event":"Attempting to relinquish lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.37+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,375","service":"samplesvc","level":"DEBUG","event":"Attempting to relinquish lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.36+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,369","service":"samplesvc","level":"DEBUG","event":"Attempting to relinquish lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.36+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,369","service":"samplesvc","level":"DEBUG","event":"Succeeded to relinquish lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.37+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,376","service":"samplesvc","level":"DEBUG","event":"Succeeded to obtain lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.37+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,376","service":"samplesvc","level":"DEBUG","event":"Attempting to obtain lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.38+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,380","service":"samplesvc","level":"DEBUG","event":"Attempting to relinquish lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.38+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,381","service":"samplesvc","level":"DEBUG","event":"Succeeded to relinquish lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.38+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,381","service":"samplesvc","level":"DEBUG","event":"Attempting to relinquish lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.38+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,382","service":"samplesvc","level":"DEBUG","event":"Attempting to obtain lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.37+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,378","service":"samplesvc","level":"DEBUG","event":"retrieve sample units excluding []"}
   2018-06-29T12:26:48.38+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,383","service":"samplesvc","level":"DEBUG","event":"retrieve sample units excluding []"}
   2018-06-29T12:26:48.38+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,385","service":"samplesvc","level":"DEBUG","event":"Attempting to relinquish lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.38+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,386","service":"samplesvc","level":"DEBUG","event":"Succeeded to relinquish lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.38+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,382","service":"samplesvc","level":"DEBUG","event":"Succeeded to obtain lock on samplesvc.sampleunit.distribution:global:lock"}
   2018-06-29T12:26:48.38+0100 [APP/PROC/WEB/0] OUT {"created":"2018-06-29 11:26:48,387","service":"samplesvc","level":"INFO","event":"SampleUnitsDistributor sleeping"}
```

# What has changed
Added environment variables
```
        LOGGING_LEVEL_uk.gov.ons.ctp.response.sample.scheduled.distribution: WARN
        LOGGING_LEVEL_uk.gov.ons.ctp.common.distributed: INFO
```

# How to test?
Fly the pipeline and check the logs aren't produced `cf logs rm-sample-service-ci`
