### PR TITLE
Add swagger dashboard deployment

### DIFF
--- a/pipelines/dashboards.yml
+++ b/pipelines/dashboards.yml
@@ -7,6 +7,11 @@ resources:
     branch: master
     private_key: ((git_key))
 
+- name: rasrm-swagger-dashboard
+  type: git
+  source:
+    uri: https://github.com/ONSdigital/rasrm-swagger-dashboard.git
+
 - name: rasrm-dashboard-space
   type: cf
   source:
@@ -18,7 +23,7 @@ resources:
     skip_cert_check: true
 
 jobs:
-- name: deploy-dashboard
+- name: deploy-performance-dashboard
   serial: true
   plan:
   - get: sdc-dashboards
@@ -46,3 +51,26 @@ jobs:
     params:
       manifest: sdc-dashboards/manifest.yml
       path: interpolated-dashboard
+
+- name: deploy-swagger-dashboard
+  serial: true
+  plan:
+  - get: rasrm-swagger-dashboard
+    trigger: true
+  - task: interpolate
+    file: rasrm-swagger-dashboard/ci/interpolate.yml
+    params:
+      SECURITY_USER_USERNAME: ((security_user_name))
+      SECURITY_USER_PASSWORD: ((security_user_password))
+  - put: rasrm-dashboard-space
+    params:
+      manifest: rasrm-swagger-dashboard/manifest.yml
+      path: interpolated-dashboard
+
+groups:
+- name: performance
+  jobs:
+  - deploy-performance-dashboard
+- name: swagger
+  jobs:
+  - deploy-swagger-dashboard

--- a/secrets/dashboard.yml.example
+++ b/secrets/dashboard.yml.example
@@ -1,0 +1,10 @@
+cloudfoundry_email:
+cloudfoundry_password:
+cloudfoundry_api:
+cloudfoundry_apps_domain:
+
+# Git
+git_key:
+
+SECURITY_USER_PASSWORD:
+SECURITY_USER_USERNAME:


### PR DESCRIPTION
# Motivation and Context
To make the swagger documentation more accessible there is a dashboard
that removes the need for username and password to be entered to see the
swagger docs against the ci services

# What has changed
Add job for swagger docs dashboard
Add groups to separate jobs

# How to test?
1. go to concourse
2. go to dashboards
3. check for green builds
4. go to http://rasrm-swagger-dashboard.apps.devtest.onsclofo.uk/
