### PR TITLE
Add SFTP details for acceptance test

### DIFF
--- a/pipelines/deployment.yml
+++ b/pipelines/deployment.yml
@@ -1798,6 +1798,11 @@ jobs:
     params:
       <<: *ci_security_user
       <<: *ci_service_endpoints_for_python
+      SFTP_HOST: ((sftp_host))
+      SFTP_PORT: '22'
+      SFTP_USERNAME: ((actionexporter_sftp_username))
+      SFTP_PASSWORD: ((actionexporter_sftp_password))
+      SFTP_DIR: BSD
       MAKE_TARGET: setup
   - task: secure-messaging-acceptance-tests
     on_failure:
@@ -2477,6 +2482,11 @@ jobs:
     params:
       <<: *latest_security_user
       <<: *latest_service_endpoints_for_python
+      SFTP_HOST: ((sftp_host))
+      SFTP_PORT: '22'
+      SFTP_USERNAME: ((actionexporter_sftp_username))
+      SFTP_PASSWORD: ((actionexporter_sftp_password))
+      SFTP_DIR: BSD
       MAKE_TARGET: acceptance_tests
 
 disabled-jobs:

--- a/pipelines/deployment.yml
+++ b/pipelines/deployment.yml
@@ -1718,6 +1718,11 @@ jobs:
     params:
       <<: *ci_security_user
       <<: *ci_service_endpoints_for_python
+      SFTP_HOST: ((sftp_host))
+      SFTP_PORT: '22'
+      SFTP_USERNAME: ((actionexporter_sftp_username))
+      SFTP_PASSWORD: ((actionexporter_sftp_password))
+      SFTP_DIR: BSD
       MAKE_TARGET: rasrm_acceptance_tests
 
 - name: ci-securemessage-acceptance-tests
@@ -1798,11 +1803,6 @@ jobs:
     params:
       <<: *ci_security_user
       <<: *ci_service_endpoints_for_python
-      SFTP_HOST: ((sftp_host))
-      SFTP_PORT: '22'
-      SFTP_USERNAME: ((actionexporter_sftp_username))
-      SFTP_PASSWORD: ((actionexporter_sftp_password))
-      SFTP_DIR: BSD
       MAKE_TARGET: setup
   - task: secure-messaging-acceptance-tests
     on_failure:


### PR DESCRIPTION
# Motivation and Context
A new acceptance test to check the generation of a notification file has
been added to rasrm-acceptance-tests
https://github.com/ONSdigital/rasrm-acceptance-tests/pull/154.
This means some new environment variables have been added and need to be
set.

# What has changed
Add SFTP credentials for https://github.com/ONSdigital/rasrm-acceptance-tests/pull/154

# How to test?
Fly pipeline after https://github.com/ONSdigital/rasrm-acceptance-tests/pull/154 is merged and run tests

# Links
- [acceptance test](https://github.com/ONSdigital/rasrm-acceptance-tests/pull/154)
- [Trello card](https://trello.com/c/Ii0xwuGt/168-add-acceptance-test-for-generating-notification-file)