### PR TITLE
Explicitly set RH to use ProductionConfig

### DIFF
--- a/pipelines/respondent-home-ui.yml
+++ b/pipelines/respondent-home-ui.yml
@@ -206,6 +206,7 @@ jobs:
       manifest: respondent-home-ui-source/manifest.yml
       path: respondent-home-ui-source
       environment_variables:
+        APP_SETTINGS: ProductionConfig
         HOST: 0.0.0.0
         LOG_LEVEL: INFO
         ACCOUNT_SERVICE_URL: https://ohs-alpha.onsdigital.uk


### PR DESCRIPTION
# Motivation and Context
ProductionConfig turns DEBUG mode of the framework off. 

Do not merge until ~[RH#33](https://github.com/ONSdigital/respondent-home-ui/pull/33)~ is merged.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Set the APP_SETTINGS to use ProductionConfig for Respondent Home UI.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://github.com/ONSdigital/respondent-home-ui/pull/33