### PR TITLE
Rename all tests from `XXXTest` to `TestXXX`

### DIFF
--- a/scripts/loadtest-scripts/tests/sdc/clients/http/test_authenticatedhttpclient.py
+++ b/scripts/loadtest-scripts/tests/sdc/clients/http/test_authenticatedhttpclient.py
@@ -6,7 +6,7 @@ from requests import Response
 from sdc.clients.http.authenticatedhttpclient import AuthenticatedHTTPClient
 
 
-class AuthenticatedHTTPClientTest(unittest.TestCase):
+class TestAuthenticatedHTTPClient(unittest.TestCase):
     USER = 'example-service-username'
     PASSWORD = 'very-secret-service-password'
 

--- a/scripts/loadtest-scripts/tests/sdc/clients/http/test_baseurlhttpclient.py
+++ b/scripts/loadtest-scripts/tests/sdc/clients/http/test_baseurlhttpclient.py
@@ -6,7 +6,7 @@ from requests import Response
 from sdc.clients.http.baseurlhttpclient import BaseURLHTTPClient
 
 
-class BaseURLHTTPClientTest(unittest.TestCase):
+class TestBaseURLHTTPClient(unittest.TestCase):
     BASE_URL = 'http://example.com/api'
     GET_RESPONSE = Response()
     POST_RESPONSE = Response()

--- a/scripts/loadtest-scripts/tests/sdc/clients/http/test_factory.py
+++ b/scripts/loadtest-scripts/tests/sdc/clients/http/test_factory.py
@@ -1,14 +1,12 @@
 import unittest
 from unittest.mock import patch
 
-from requests import Response
-
 from sdc.clients.http import factory
 from sdc.clients.http.httpcodeexception import HTTPCodeException
 from tests.shared.requests import Requests
 
 
-class HTTPClientFactoryTest(unittest.TestCase, Requests):
+class TestHTTPClientFactory(unittest.TestCase, Requests):
     BASE_URL = 'http://example.com'
     PASSWORD = 'example-pass'
     USERNAME = 'example-user'

--- a/scripts/loadtest-scripts/tests/sdc/clients/services/test_actionserviceclient.py
+++ b/scripts/loadtest-scripts/tests/sdc/clients/services/test_actionserviceclient.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 from sdc.clients.services import ActionServiceClient
 
 
-class ActionServiceClientTest(unittest.TestCase):
+class TestActionServiceClient(unittest.TestCase):
     def setUp(self):
         self.http_client = Mock()
         self.client = ActionServiceClient(self.http_client)

--- a/scripts/loadtest-scripts/tests/sdc/clients/services/test_caseclient.py
+++ b/scripts/loadtest-scripts/tests/sdc/clients/services/test_caseclient.py
@@ -6,7 +6,7 @@ from requests import Response
 from sdc.clients.services import CaseServiceClient
 
 
-class CaseServiceClientTest(unittest.TestCase):
+class TestCaseServiceClient(unittest.TestCase):
     def setUp(self):
         self.http_client = Mock()
         self.client = CaseServiceClient(self.http_client)

--- a/scripts/loadtest-scripts/tests/sdc/clients/services/test_collectionexerciseserviceclient.py
+++ b/scripts/loadtest-scripts/tests/sdc/clients/services/test_collectionexerciseserviceclient.py
@@ -6,7 +6,7 @@ from sdc.clients.services import CollectionExerciseServiceClient
 from tests.shared.requests import Requests
 
 
-class CollectionExerciseServiceClientTest(unittest.TestCase, Requests):
+class TestCollectionExerciseServiceClient(unittest.TestCase, Requests):
     def setUp(self):
         http_response = self.http_response(status_code=200)
 

--- a/scripts/loadtest-scripts/tests/sdc/clients/services/test_collectioninstrumentserviceclient.py
+++ b/scripts/loadtest-scripts/tests/sdc/clients/services/test_collectioninstrumentserviceclient.py
@@ -5,7 +5,7 @@ from sdc.clients.services import CollectionInstrumentServiceClient
 from tests.shared.requests import Requests
 
 
-class CollectionInstrumentServiceClientTest(unittest.TestCase, Requests):
+class TestCollectionInstrumentServiceClient(unittest.TestCase, Requests):
     def setUp(self):
         self.http_client = Mock()
         self.client = CollectionInstrumentServiceClient(http_client=self.http_client)

--- a/scripts/loadtest-scripts/tests/sdc/clients/services/test_partserviceclient.py
+++ b/scripts/loadtest-scripts/tests/sdc/clients/services/test_partserviceclient.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 from sdc.clients.services import partyserviceclient
 
 
-class PartyServiceClientTest(unittest.TestCase):
+class TestPartyServiceClient(unittest.TestCase):
     def setUp(self):
         self.http_client = Mock()
         self.client = partyserviceclient.PartyServiceClient(http_client=self.http_client)

--- a/scripts/loadtest-scripts/tests/sdc/clients/services/test_sampleserviceclient.py
+++ b/scripts/loadtest-scripts/tests/sdc/clients/services/test_sampleserviceclient.py
@@ -6,7 +6,7 @@ from sdc.clients.services import SampleServiceClient
 from tests.shared.requests import Requests
 
 
-class SampleServiceClientTest(unittest.TestCase, Requests):
+class TestSampleServiceClient(unittest.TestCase, Requests):
     def setUp(self):
         self.http_client = Mock()
 

--- a/scripts/loadtest-scripts/tests/sdc/clients/test_actions.py
+++ b/scripts/loadtest-scripts/tests/sdc/clients/test_actions.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 from sdc.clients.actions import Actions
 
 
-class ActionsTest(unittest.TestCase):
+class TestActions(unittest.TestCase):
     EXERCISE_ID = '9281d5b4-c1bf-4322-9f34-683b266bc3b2'
     BUSINESS_CASE_ACTION_PLAN_ID = '4d8be6f8-492e-4ef9-b741-d178499736dd'
     COLLECTION_EXERCISE = {

--- a/scripts/loadtest-scripts/tests/sdc/clients/test_enrolmentcodes.py
+++ b/scripts/loadtest-scripts/tests/sdc/clients/test_enrolmentcodes.py
@@ -7,7 +7,7 @@ from sdc.clients.enrolmentcodes import EnrolmentCodes, RemoteFileNotFoundExcepti
     MultipleRemoteFilesFoundException, IncorrectNumberOfEnrolmentCodes
 
 
-class EnrolmentCodesTest(unittest.TestCase):
+class TestEnrolmentCodes(unittest.TestCase):
     BASE_DIR = 'BSD'
 
     def setUp(self):

--- a/scripts/loadtest-scripts/tests/sdc/clients/test_notifymockclient.py
+++ b/scripts/loadtest-scripts/tests/sdc/clients/test_notifymockclient.py
@@ -6,7 +6,7 @@ from sdc.clients.notifymockclient import NotifyMockClient
 from tests.shared.requests import Requests
 
 
-class NotifyMockClientTest(unittest.TestCase, Requests):
+class TestNotifyMockClient(unittest.TestCase, Requests):
     def setUp(self):
         self.http_client = Mock()
         self.client = NotifyMockClient(self.http_client)

--- a/scripts/loadtest-scripts/tests/sdc/clients/test_sdcclient_integration.py
+++ b/scripts/loadtest-scripts/tests/sdc/clients/test_sdcclient_integration.py
@@ -11,7 +11,7 @@ from sdc.clients.users import NoVerificationEmailFound
 
 
 @pytest.mark.usefixtures('sftpserver')
-class SDCClientIntegrationTest(unittest.TestCase):
+class TestSDCClientIntegration(unittest.TestCase):
     def setUp(self):
         self.client = SDCClient(self._config())
 

--- a/scripts/loadtest-scripts/tests/sdc/clients/test_sftpclient.py
+++ b/scripts/loadtest-scripts/tests/sdc/clients/test_sftpclient.py
@@ -6,7 +6,7 @@ from sdc.clients.sftpclient import SFTPClient
 
 
 @pytest.mark.usefixtures('sftpserver')
-class SFTPClientTest(unittest.TestCase):
+class TestSFTPClient(unittest.TestCase):
     def test_ls_lists_files_matching_a_glob_pattern(self):
         files = {
             'readme.txt': 'Text file in the root',

--- a/scripts/loadtest-scripts/tests/sdc/clients/users_test.py
+++ b/scripts/loadtest-scripts/tests/sdc/clients/users_test.py
@@ -8,7 +8,7 @@ from sdc.clients.users import Users, NoVerificationEmailFound, MultipleEmailsFou
 from tests.shared.requests import Requests
 
 
-class UsersTest(unittest.TestCase, Requests):
+class TestUsers(unittest.TestCase, Requests):
     VERIFICATION_LINK = \
         "http://frontstage.services.com/register/activate-account/" \
         "InVzZXItMjAxODA1LTFAZXhhbXBsZS5jb20i.DkXhaw.DbfocE4M99mRWhu3HbBVVRavjsY"


### PR DESCRIPTION
# Motivation and Context
This seems to be the preferred Python convention.