### PR TITLE
remove the task which maps RH to the ohs-alpha.onsdigital.uk route

### DIFF
--- a/pipelines/respondent-home-ui.yml
+++ b/pipelines/respondent-home-ui.yml
@@ -173,12 +173,6 @@ jobs:
       command: map-route
       app_name: respondent-home-ui-preprod
       domain: rhpreprod.rmdev.onsdigital.uk
-  - put: map-route-ons-internal-domain
-    resource: cf-cli-resource-preprod
-    params:
-      command: map-route
-      app_name: respondent-home-ui-preprod
-      domain: ohs-alpha.onsdigital.uk
   - task: smoke-tests
     on_failure:
       put: notify


### PR DESCRIPTION
# Motivation and Context
Social test1 has now finished and there is an IA requirement to stop using the https://ohs-alpha.onsdigital.uk/ address

# What has changed
The task which maps the ohs-alpha.onsdigital.uk route to RH has been removed in the pipeline


# How to test?
when RH next gets deployed https://ohs-alpha.onsdigital.uk should not be accessible