### PR TITLE
Add metrics services to the performance pipeline

### DIFF
--- a/pipelines/performance.yml
+++ b/pipelines/performance.yml
@@ -206,6 +206,12 @@ resources:
     uri: https://github.com/ONSdigital/ras-deploy.git
     branch: master
 
+- name: ras-rm-metrics-source
+  type: git
+  source:
+    uri: https://github.com/ONSdigital/ras-rm-metrics
+    branch: master
+
 - name: ras-rm-performance-tests
   type: git
   source:
@@ -1119,6 +1125,21 @@ jobs:
   - task: check-status-of-apps
     file: ras-deploy/tasks/cloudfoundry-scripts/health_check.yml
 
+- name: ras-rm-metrics-deploy
+  serial: true
+  plan:
+  - get: ras-rm-metrics-source
+    trigger: true
+  - put: push-app
+    resource: cf-resource-((performance_cloudfoundry_space))
+    params:
+      current_app_name: ras-rm-metrics-((performance_cloudfoundry_space))
+      manifest: ras-rm-metrics-source/manifest.yml
+      path: ras-rm-metrics-source
+      environment_variables:
+        SCHEDULER_FREQUENCY: '15'
+        RABBITMQ_SERVICE_NAME: rabbitmq
+
 groups:
 - name: pipeline
   jobs:
@@ -1143,6 +1164,7 @@ groups:
 - name: support
   jobs:
   - sdc-mock-gov-notify-deploy
+  - ras-rm-metric-deploy
 - name: status
   jobs:
   - platform-status


### PR DESCRIPTION
# Motivation and Context
So that rabbitmq queue sizes can be monitored during performance tests.
