### PR TITLE
Cache maven dependencies

### DIFF
--- a/tasks/build-java-service-skip-IT.yml
+++ b/tasks/build-java-service-skip-IT.yml
@@ -14,10 +14,14 @@ outputs:
   - name: target
     path: target
 
+caches:
+  - path: repository-name/.m2/
+
 run:
   path: sh
   args:
   - -exc
   - |
-    mvn --settings repository-name/.maven.settings.xml install -Ddockerfile.skip -Ddocker.skip -DskipITs -Dhttp.wait.skip -f repository-name/pom.xml
+    mkdir -p .m2/repository
+    mvn --settings repository-name/.maven.settings.xml install -Ddockerfile.skip -Ddocker.skip -DskipITs -Dhttp.wait.skip -f repository-name/pom.xml -Dmaven.repo.local=.m2/repository
     cp -r repository-name/target/ .

--- a/tasks/build-java-service-skip-IT.yml
+++ b/tasks/build-java-service-skip-IT.yml
@@ -15,7 +15,7 @@ outputs:
     path: target
 
 caches:
-  - path: repository-name/.m2/
+  - path: .m2/repository
 
 run:
   path: sh

--- a/tasks/build-java-service.yml
+++ b/tasks/build-java-service.yml
@@ -14,11 +14,14 @@ outputs:
   - name: target
     path: target
 
+caches:
+  - path: repository-name/.m2/
+
 run:
   path: sh
   args:
   - -exc
   - |
-    mvn --settings repository-name/.maven.settings.xml install -Ddockerfile.skip -f repository-name/pom.xml
+    mkdir -p .m2/repository
+    mvn --settings repository-name/.maven.settings.xml install -Ddockerfile.skip -f repository-name/pom.xml -Dmaven.repo.local=.m2/repository
     cp -r repository-name/target/ .
-    

--- a/tasks/build-java-service.yml
+++ b/tasks/build-java-service.yml
@@ -15,7 +15,7 @@ outputs:
     path: target
 
 caches:
-  - path: repository-name/.m2/
+  - path: .m2/repository
 
 run:
   path: sh


### PR DESCRIPTION
# Motivation and Context
Caching maven dependencies should speed the build up

# What has changed
Add cache directory and tell maven to use the cache directory

# How to test?
The pipeline is currently flow with this configuration so kick off a java build and check if it's faster