### PR TITLE
Revert time back for ci-teardown-timer

### DIFF
--- a/pipelines/deployment.yml
+++ b/pipelines/deployment.yml
@@ -920,9 +920,8 @@ resources:
 - name: ci-teardown-timer
   type: time
   source:
-    start: 3:00 PM
-    stop: 4:00 PM
-    location: Europe/London
+    start: 6AM
+    stop: 7AM
 
 - name: cf-cli-resource-latest
   type: cf-cli-resource


### PR DESCRIPTION
# Motivation and Context
So the new pipeline changes went in and this was missed in the reviews i.e. the `ci-teardown-timer` was set at a new time for testing and not reverted back to the previous time.

This PR aims to to revert the `ci-teardown-timer` back to the previous time for early in the morning instead of 3:00/4:00PM

# What has changed
`ci-teardown-timer` reverted back to previous time

# How to test?
Just approve it

# Links
Based off this PR: https://github.com/ONSdigital/ras-deploy/pull/74
