### PR TITLE
Fix comms template config syntax

### DIFF
--- a/pipelines/deployment.yml
+++ b/pipelines/deployment.yml
@@ -199,7 +199,7 @@ templates:
       caseSvc_connectionConfig_username: ((latest_security_user_name))
       caseSvc_connectionConfig_password: ((latest_security_user_password))
       commsTemplateService_connectionConfig_username: ((latest_security_user_name))
-      commsTemplateService_connectionConfig_password: ((latest_security_user_password
+      commsTemplateService_connectionConfig_password: ((latest_security_user_password))
       collectionExerciseSvc_connectionConfig_username: ((latest_security_user_name))
       collectionExerciseSvc_connectionConfig_password: ((latest_security_user_password))
       collectionInstrumentSvc_connectionConfig_username: ((latest_security_user_name))


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Password for comms template service will not parse as an environment variable due to a missing `))`
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Added `))` to `commsTemplateService_connectionConfig_password`

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Pipeline has already been flown with this change.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
N/A