### PR TITLE
Increase scheduler time to run every 30 seconds

### DIFF
--- a/pipelines/deployment.yml
+++ b/pipelines/deployment.yml
@@ -1361,7 +1361,7 @@ jobs:
       environment_variables:
         <<: *ci_security_user
         endpoints_enabled: 'false'
-        exportSchedule_cronExpression: '* * * * * *'
+        exportSchedule_cronExpression: '*/30 * * * * *'
         sftp_host: ((sftp_host))
         sftp_password: ((actionexporter_sftp_password))
         sftp_port: '22'
@@ -2252,7 +2252,7 @@ jobs:
       environment_variables:
         <<: *latest_security_user
         endpoints_enabled: 'false'
-        exportSchedule_cronExpression: '* * * * * *'
+        exportSchedule_cronExpression: '*/30 * * * * *'
         sftp_host: ((sftp_host))
         sftp_password: ((actionexporter_sftp_password))
         sftp_port: '22'


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Running the sceduler every second is overkill.
Changed to every 30 seconds.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
CI pipeline stays green

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
