### PR TITLE
Add URL path prefix for Respondent-Home-UI Prod

### DIFF
--- a/pipelines/respondent-home-ui.yml
+++ b/pipelines/respondent-home-ui.yml
@@ -231,6 +231,7 @@ jobs:
         SAMPLE_USERNAME: ((prod_security_user_name))
         SAMPLE_PASSWORD: ((prod_security_user_password))
         SECRET_KEY: ((prod_rh_secret_key))
+        URL_PATH_PREFIX: /myStudy
 
   - task: smoke-tests
     on_failure:


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A URL prefix can now be given to Respondent-Home-UI routes. 

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
An optional URL prefix has been added to production, and will be picked up by the app when deployed.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
* Tricky to test. The change to the pipeline can be tested via the application after it has been deployed to production.
* Dependent on [this PR](https://github.com/ONSdigital/respondent-home-ui/pull/51).

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/vteevzP4/219-sus012-ext-setup-url)