### PR TITLE
Map route for ONS internal pre-prod

### DIFF
--- a/pipelines/respondent-home-ui.yml
+++ b/pipelines/respondent-home-ui.yml
@@ -16,6 +16,7 @@ resources:
   type: git
   source:
     uri: https://github.com/ONSdigital/respondent-home-ui.git
+    branch: master
 
 - name: cf-resource-latest
   type: cf
@@ -173,6 +174,12 @@ jobs:
       command: map-route
       app_name: respondent-home-ui-preprod
       domain: rhpreprod.rmdev.onsdigital.uk
+  - put: map-route-ons-internal-domain
+    resource: cf-cli-resource-preprod
+    params:
+      app_name: respondent-home-ui-preprod
+      command: map-route
+      domain: ohs-alpha.onsdigital.uk
   - task: smoke-tests
     on_failure:
       put: notify


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Raised on behalf of @davidmort. The pre-prod respondent-home-ui app can be accessed through an additional route for testing purposes. This updates the pipeline to make sure this is used.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Updated the pre-prod resource for respondent-home-ui.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
N / A

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
N / A