### PR TITLE
Enable external routes for RH

### DIFF
--- a/pipelines/respondent-home-ui.yml
+++ b/pipelines/respondent-home-ui.yml
@@ -119,6 +119,7 @@ jobs:
           $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
     file: respondent-home-ui-source/ci/smoke_tests.yml
     params:
+      RESPONDENT_HOME_INTERNAL_URL: https://respondent-home-ui-latest.apps.devtest.onsclofo.uk
       RESPONDENT_HOME_URL: https://respondent-home-ui-latest.apps.devtest.onsclofo.uk
 
 - name: respondent-home-ui-preprod-deploy
@@ -197,7 +198,8 @@ jobs:
           $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
     file: respondent-home-ui-source/ci/smoke_tests.yml
     params:
-      RESPONDENT_HOME_URL: https://respondent-home-ui-preprod.((preprod_cloudfoundry_apps_domain))
+      RESPONDENT_HOME_INTERNAL_URL: https://respondent-home-ui-preprod.((preprod_cloudfoundry_apps_domain))
+      RESPONDENT_HOME_URL: https://((preprod_domain))
       URL_PATH_PREFIX: /((preprod_path))
 
 - name: respondent-home-ui-prod-deploy
@@ -265,5 +267,6 @@ jobs:
           $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
     file: respondent-home-ui-source/ci/smoke_tests.yml
     params:
-      RESPONDENT_HOME_URL: https://respondent-home-ui-prod.((prod_cloudfoundry_apps_domain))
+      RESPONDENT_HOME_INTERNAL_URL: https://respondent-home-ui-prod.((prod_cloudfoundry_apps_domain))
+      RESPONDENT_HOME_URL: https://((prod_domain))
       URL_PATH_PREFIX: /((prod_path))

--- a/pipelines/respondent-home-ui.yml
+++ b/pipelines/respondent-home-ui.yml
@@ -142,7 +142,7 @@ jobs:
       environment_variables:
         HOST: 0.0.0.0
         LOG_LEVEL: INFO
-        ACCOUNT_SERVICE_URL: https://ohs-alpha.onsdigital.uk
+        ACCOUNT_SERVICE_URL: ((preprod_account_service_url))
         EQ_URL: https://eq.onsdigital.uk
         JSON_SECRET_KEYS: ((preprod_json_secret_keys))
         CASE_URL: http://casesvc-preprod.((preprod_cloudfoundry_apps_domain))
@@ -180,6 +180,13 @@ jobs:
       app_name: respondent-home-ui-preprod
       command: map-route
       domain: ohs-alpha.onsdigital.uk
+  - put: map-route-ons-external-preprod-domain
+    resource: cf-cli-resource-preprod
+    params:
+      app_name: respondent-home-ui-preprod
+      command: map-route
+      domain: ((preprod_domain))
+      path: ((preprod_path))
   - task: smoke-tests
     on_failure:
       put: notify
@@ -238,8 +245,15 @@ jobs:
         SAMPLE_USERNAME: ((prod_security_user_name))
         SAMPLE_PASSWORD: ((prod_security_user_password))
         SECRET_KEY: ((prod_rh_secret_key))
-        URL_PATH_PREFIX: /myStudy
+        URL_PATH_PREFIX: /mystudy
 
+  - put: map-route-ons-external-prod-domain
+    resource: cf-cli-resource-prod
+    params:
+      app_name: respondent-home-ui-prod
+      command: map-route
+      domain: ((prod_domain))
+      path: ((prod_path))
   - task: smoke-tests
     on_failure:
       put: notify

--- a/pipelines/respondent-home-ui.yml
+++ b/pipelines/respondent-home-ui.yml
@@ -84,7 +84,7 @@ jobs:
       environment_variables:
         HOST: 0.0.0.0
         LOG_LEVEL: INFO
-        ACCOUNT_SERVICE_URL: http://respondent-home-ui-latest.apps.devtest.onsclofo.uk
+        ACCOUNT_SERVICE_URL: http://respondent-home-ui-latest.apps.devtest.onsclofo.uk      # Remember to exclude all path prefixes here
         EQ_URL: https://staging-new-surveys.dev.eq.ons.digital
         JSON_SECRET_KEYS: ((latest_json_secret_keys))
         CASE_URL: http://rm-case-service-concourse-latest.apps.devtest.onsclofo.uk
@@ -142,7 +142,7 @@ jobs:
       environment_variables:
         HOST: 0.0.0.0
         LOG_LEVEL: INFO
-        ACCOUNT_SERVICE_URL: ((preprod_account_service_url))
+        ACCOUNT_SERVICE_URL: ((preprod_account_service_url))    # Remember to exclude all path prefixes here
         EQ_URL: https://eq.onsdigital.uk
         JSON_SECRET_KEYS: ((preprod_json_secret_keys))
         CASE_URL: http://casesvc-preprod.((preprod_cloudfoundry_apps_domain))
@@ -167,6 +167,7 @@ jobs:
         SAMPLE_USERNAME: ((preprod_security_user_name))
         SAMPLE_PASSWORD: ((preprod_security_user_password))
         SECRET_KEY: ((preprod_rh_secret_key))
+        URL_PATH_PREFIX: /((preprod_path))
 
   - put: map-route-vpn-domain
     resource: cf-cli-resource-preprod
@@ -180,7 +181,7 @@ jobs:
       app_name: respondent-home-ui-preprod
       command: map-route
       domain: ohs-alpha.onsdigital.uk
-  - put: map-route-ons-external-preprod-domain
+  - put: map-route-ons-internal-preprod-domain
     resource: cf-cli-resource-preprod
     params:
       app_name: respondent-home-ui-preprod
@@ -197,6 +198,7 @@ jobs:
     file: respondent-home-ui-source/ci/smoke_tests.yml
     params:
       RESPONDENT_HOME_URL: https://respondent-home-ui-preprod.((preprod_cloudfoundry_apps_domain))
+      URL_PATH_PREFIX: /((preprod_path))
 
 - name: respondent-home-ui-prod-deploy
   serial: true
@@ -220,7 +222,7 @@ jobs:
         APP_SETTINGS: ProductionConfig
         HOST: 0.0.0.0
         LOG_LEVEL: INFO
-        ACCOUNT_SERVICE_URL: ((prod_account_service_url))
+        ACCOUNT_SERVICE_URL: ((prod_account_service_url))   # Remember to exclude all path prefixes here
         EQ_URL: https://eq.ons.gov.uk
         JSON_SECRET_KEYS: ((prod_json_secret_keys))
         CASE_URL: http://casesvc-prod.((prod_cloudfoundry_apps_domain))
@@ -245,7 +247,7 @@ jobs:
         SAMPLE_USERNAME: ((prod_security_user_name))
         SAMPLE_PASSWORD: ((prod_security_user_password))
         SECRET_KEY: ((prod_rh_secret_key))
-        URL_PATH_PREFIX: /mystudy
+        URL_PATH_PREFIX: /((prod_path))
 
   - put: map-route-ons-external-prod-domain
     resource: cf-cli-resource-prod
@@ -264,3 +266,4 @@ jobs:
     file: respondent-home-ui-source/ci/smoke_tests.yml
     params:
       RESPONDENT_HOME_URL: https://respondent-home-ui-prod.((prod_cloudfoundry_apps_domain))
+      URL_PATH_PREFIX: /((prod_path))

--- a/secrets/respondent-home-ui-vars.yml.example
+++ b/secrets/respondent-home-ui-vars.yml.example
@@ -23,6 +23,9 @@ latest_json_secret_keys:
 latest_rh_secret_key:
 
 # Preprod secrets
+preprod_account_service_url:
+preprod_domain:
+preprod_path:
 preprod_security_user_name:
 preprod_security_user_password:
 preprod_json_secret_keys:
@@ -30,6 +33,8 @@ preprod_rh_secret_key:
 
 # Prod secrets
 prod_account_service_url:
+prod_domain:
+prod_path:
 prod_security_user_name:
 prod_security_user_password:
 prod_json_secret_keys:

--- a/secrets/respondent-home-ui-vars.yml.example
+++ b/secrets/respondent-home-ui-vars.yml.example
@@ -23,7 +23,7 @@ latest_json_secret_keys:
 latest_rh_secret_key:
 
 # Preprod secrets
-preprod_account_service_url:
+preprod_account_service_url:        # Remember to exclude all path prefixes here
 preprod_domain:
 preprod_path:
 preprod_security_user_name:
@@ -32,7 +32,7 @@ preprod_json_secret_keys:
 preprod_rh_secret_key:
 
 # Prod secrets
-prod_account_service_url:
+prod_account_service_url:           # Remember to exclude all path prefixes here
 prod_domain:
 prod_path:
 prod_security_user_name:


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to ensure Respondent Home UI uses a specific domain and path for preprod & prod. This also need to be included for the smoke tests.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Add a new routing job for preprod and prod
* Allow `URL_PATH_PREFIX` to be used in smoke tests

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
The pipeline will be updated after this PR has been approved. The secrets will need to be updated before this happens.

Dependent on [this PR](https://github.com/ONSdigital/respondent-home-ui/compare/update-smoke-test-assertion?expand=1)

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/vteevzP4/219-sus012-ext-setup-url)