### PR TITLE
Update RH smoke test to use internal app

### DIFF
--- a/pipelines/respondent-home-ui.yml
+++ b/pipelines/respondent-home-ui.yml
@@ -209,7 +209,7 @@ jobs:
     file: respondent-home-ui-source/ci/smoke_tests.yml
     params:
       RESPONDENT_HOME_INTERNAL_URL: https://respondent-home-ui-preprod.((preprod_cloudfoundry_apps_domain))
-      RESPONDENT_HOME_URL: https://((preprod_domain))
+      RESPONDENT_HOME_URL: https://respondent-home-ui-preprod.((preprod_cloudfoundry_apps_domain))
       URL_PATH_PREFIX: /((preprod_path))
 
 - name: respondent-home-ui-prod-deploy


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Until the domain used for the pre-prod smoke test is whitelisted for Concourse, we'll use the internal Cloud Foundry app domain for now. 

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Updated the RH pipeline so RESPONDENT_HOME_URL now uses the internal Cloud Foundry URL instead.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
These changes have already been made to allow the smoke tests to pass in pre-prod. This PR just ensures master is kept up-to-date.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/vteevzP4/219-sus012-ext-setup-url)