### PR TITLE
enable FEATURE_ENABLE_CLOSE_CONVERSATION feature flag in ROps in CI

### DIFF
--- a/pipelines/deployment.yml
+++ b/pipelines/deployment.yml
@@ -1327,6 +1327,7 @@ jobs:
         REDIS_SERVICE: ras-redis
         UAA_CLIENT_ID: 'response_operations'
         UAA_CLIENT_SECRET: ((ci_response_operations_client_secret))
+	FEATURE_ENABLE_CLOSE_CONVERSATION: 'True'
 
 - name: response-operations-social-ui-ci-deploy
   serial_groups: [response-operations-social-ui-ci-deploy]


### PR DESCRIPTION
# Motivation and Context
We need to set the FEATURE_ENABLE_CLOSE_CONVERSATION feature flag in CI so tests will pass

# What has changed
FEATURE_ENABLE_CLOSE_CONVERSATION set to True
