### PR TITLE
Added skip variable for building java services

### DIFF
--- a/tasks/build-java-service-skip-IT.yml
+++ b/tasks/build-java-service-skip-IT.yml
@@ -23,5 +23,5 @@ run:
   - -exc
   - |
     mkdir -p .m2/repository
-    mvn --settings repository-name/.maven.settings.xml install -Ddockerfile.skip -Ddocker.skip -DskipITs -Dhttp.wait.skip -f repository-name/pom.xml -Dmaven.repo.local=.m2/repository
+    mvn --settings repository-name/.maven.settings.xml install -DdockerComposeSkip -Ddockerfile.skip -Ddocker.skip -DskipITs -Dhttp.wait.skip -f repository-name/pom.xml -Dmaven.repo.local=.m2/repository
     cp -r repository-name/target/ .


### PR DESCRIPTION
# Motivation and Context
A new plugin for docker was put into the case service and a variable needs to be added to the mvn command to skip over the new `docker-compose-maven-plugin`
# What has changed
- Added `-DdockerComposeSkip` to the mvn command to run and skip over integration tests

# How to test?
To make sure the command works, go to the case service and run `mvn clean install -DdockerComposeSkip  -Ddockerfile.skip -Ddocker.skip -DskipITs -Dhttp.wait.skip`. It should skip over all docker plugins and integration tests
