### PR TITLE
Respondent home UI deploy on releases

### DIFF
--- a/pipelines/respondent-home-ui.yml
+++ b/pipelines/respondent-home-ui.yml
@@ -29,12 +29,14 @@ resources:
   source:
     owner: ONSdigital
     repository: respondent-home-ui
+    access_token: ((github_access_token))
 
 - name: respondent-home-ui-pre-release
   type: github-release
   source:
     owner: ONSdigital
     repository: respondent-home-ui
+    access_token: ((github_access_token))
     release: false
     pre_release: true
 

--- a/pipelines/respondent-home-ui.yml
+++ b/pipelines/respondent-home-ui.yml
@@ -18,6 +18,12 @@ resources:
     uri: https://github.com/ONSdigital/respondent-home-ui.git
     branch: master
 
+- name: ras-deploy
+  type: git
+  source:
+    uri: https://github.com/ONSdigital/ras-deploy.git
+    branch: master
+
 - name: respondent-home-ui-release
   type: github-release
   source:
@@ -99,7 +105,7 @@ jobs:
       put: notify
       params:
         text:  |
-          Latest respondent-home-ui deployment failed. See build:
+          Latest space respondent-home-ui deployment failed. See build:
           $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
     params:
       current_app_name: respondent-home-ui-latest
@@ -139,7 +145,7 @@ jobs:
       put: notify
       params:
         text:  |
-          Latest smoke tests failed. Check the build:
+          Latest space respondent-home-ui smoke tests failed. Check the build:
           $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
     file: respondent-home-ui-source/ci/smoke_tests.yml
     params:
@@ -154,24 +160,11 @@ jobs:
     trigger: true
     params:
       include_source_tarball: true
-  - task: extract-release-source
-    config:
-      platform: linux
-      image_resource:
-        type: docker-image
-        source:
-          repository: alpine
-          tag: latest
-      inputs:
-      - name: respondent-home-ui-pre-release
-      outputs:
-      - name: respondent-home-ui-pre-release-source
-      run:
-        path: sh
-        args:
-        - -exc
-        - |
-          tar -xzf respondent-home-ui-pre-release/source.tar.gz -C respondent-home-ui-pre-release-source --strip-components=1
+  - get: ras-deploy
+  - task: extract-source-from-release-tarball
+    file: ras-deploy/tasks/extract-source-from-release.yml
+    input_mapping: { release-resource: respondent-home-ui-pre-release }
+    output_mapping: { release-source: respondent-home-ui-pre-release-source }
   - put: push-app
     resource: cf-resource-preprod
     on_failure:
@@ -182,8 +175,8 @@ jobs:
           $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
     params:
       current_app_name: respondent-home-ui-preprod
-      manifest: rrespondent-home-ui-release-source/manifest.yml
-      path: respondent-home-ui-release-source
+      manifest: respondent-home-ui-pre-release-source/manifest.yml
+      path: respondent-home-ui-pre-release-source
       environment_variables:
         HOST: 0.0.0.0
         LOG_LEVEL: INFO
@@ -239,7 +232,7 @@ jobs:
       put: notify
       params:
         text:  |
-          Pre-production smoke tests failed. Check the build:
+          Pre-production respondent-home-ui smoke tests failed. Check the build:
           $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
     file: respondent-home-ui-release-source/ci/smoke_tests.yml
     params:
@@ -255,24 +248,11 @@ jobs:
     trigger: true
     params:
       include_source_tarball: true
-  - task: extract-release-source
-    config:
-      platform: linux
-      image_resource:
-        type: docker-image
-        source:
-          repository: alpine
-          tag: latest
-      inputs:
-      - name: respondent-home-ui-release
-      outputs:
-      - name: respondent-home-ui-release-source
-      run:
-        path: sh
-        args:
-        - -exc
-        - |
-          tar -xzf respondent-home-ui-release/source.tar.gz -C respondent-home-ui-release-source --strip-components=1
+  - get: ras-deploy
+  - task: extract-source-from-release-tarball
+    file: ras-deploy/tasks/extract-source-from-release.yml
+    input_mapping: { release-resource: respondent-home-ui-release }
+    output_mapping: { release-source: respondent-home-ui-release-source }
   - put: push-app
     resource: cf-resource-preprod
     on_failure:
@@ -340,7 +320,7 @@ jobs:
       put: notify
       params:
         text:  |
-          Pre-production smoke tests failed. Check the build:
+          Pre-production respondent-home-ui smoke tests failed. Check the build:
           $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
     file: respondent-home-ui-release-source/ci/smoke_tests.yml
     params:
@@ -356,24 +336,11 @@ jobs:
     trigger: true
     params:
       include_source_tarball: true
-  - task: extract-release-source
-    config:
-      platform: linux
-      image_resource:
-        type: docker-image
-        source:
-          repository: alpine
-          tag: latest
-      inputs:
-      - name: respondent-home-ui-release
-      outputs:
-      - name: respondent-home-ui-release-source
-      run:
-        path: sh
-        args:
-        - -exc
-        - |
-          tar -xzf respondent-home-ui-release/source.tar.gz -C respondent-home-ui-release-source --strip-components=1
+  - get: ras-deploy
+  - task: extract-source-from-release-tarball
+    file: ras-deploy/tasks/extract-source-from-release.yml
+    input_mapping: { release-resource: respondent-home-ui-release }
+    output_mapping: { release-source: respondent-home-ui-release-source }
   - put: push-app
     resource: cf-resource-prod
     on_failure:
@@ -430,7 +397,7 @@ jobs:
       put: notify
       params:
         text:  |
-          Production smoke tests failed. Check the build:
+          Production respondent-home-ui smoke tests failed. Check the build:
           $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
     file: respondent-home-ui-release-source/ci/smoke_tests.yml
     params:

--- a/pipelines/respondent-home-ui.yml
+++ b/pipelines/respondent-home-ui.yml
@@ -18,6 +18,20 @@ resources:
     uri: https://github.com/ONSdigital/respondent-home-ui.git
     branch: master
 
+- name: respondent-home-ui-release
+  type: github-release
+  source:
+    user: ONSdigital
+    repository: respondent-home-ui
+
+- name: respondent-home-ui-pre-release
+  type: github-release
+  source:
+    user: ONSdigital
+    repository: respondent-home-ui
+    release: false
+    pre_release: true
+
 - name: cf-resource-latest
   type: cf
   source:
@@ -132,12 +146,32 @@ jobs:
       RESPONDENT_HOME_INTERNAL_URL: https://respondent-home-ui-latest.apps.devtest.onsclofo.uk
       RESPONDENT_HOME_URL: https://respondent-home-ui-latest.apps.devtest.onsclofo.uk
 
-- name: respondent-home-ui-preprod-deploy
+- name: respondent-home-ui-preprod-pre-release-deploy
   serial: true
+  serial_groups: [preprod_deploys]
   plan:
-  - get: respondent-home-ui-source
-    passed: [respondent-home-ui-latest-deploy]
+  - get: respondent-home-ui-pre-release
     trigger: true
+    params:
+      include_source_tarball: true
+  - task: extract-release-source
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: alpine
+          tag: latest
+      inputs:
+      - name: respondent-home-ui-pre-release
+      outputs:
+      - name: respondent-home-ui-pre-release-source
+      run:
+        path: sh
+        args:
+        - -exc
+        - |
+          tar -xzf respondent-home-ui-pre-release/source.tar.gz -C respondent-home-ui-pre-release-source --strip-components=1
   - put: push-app
     resource: cf-resource-preprod
     on_failure:
@@ -148,8 +182,8 @@ jobs:
           $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
     params:
       current_app_name: respondent-home-ui-preprod
-      manifest: respondent-home-ui-source/manifest.yml
-      path: respondent-home-ui-source
+      manifest: rrespondent-home-ui-release-source/manifest.yml
+      path: respondent-home-ui-release-source
       environment_variables:
         HOST: 0.0.0.0
         LOG_LEVEL: INFO
@@ -207,7 +241,108 @@ jobs:
         text:  |
           Pre-production smoke tests failed. Check the build:
           $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
-    file: respondent-home-ui-source/ci/smoke_tests.yml
+    file: respondent-home-ui-release-source/ci/smoke_tests.yml
+    params:
+      RESPONDENT_HOME_INTERNAL_URL: https://respondent-home-ui-preprod.((preprod_cloudfoundry_apps_domain))
+      RESPONDENT_HOME_URL: https://respondent-home-ui-preprod.((preprod_cloudfoundry_apps_domain))
+      URL_PATH_PREFIX: /((preprod_path))
+
+- name: respondent-home-ui-preprod-deploy
+  serial: true
+  serial_groups: [preprod_deploys]
+  plan:
+  - get: respondent-home-ui-release
+    trigger: true
+    params:
+      include_source_tarball: true
+  - task: extract-release-source
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: alpine
+          tag: latest
+      inputs:
+      - name: respondent-home-ui-release
+      outputs:
+      - name: respondent-home-ui-release-source
+      run:
+        path: sh
+        args:
+        - -exc
+        - |
+          tar -xzf respondent-home-ui-release/source.tar.gz -C respondent-home-ui-release-source --strip-components=1
+  - put: push-app
+    resource: cf-resource-preprod
+    on_failure:
+      put: notify
+      params:
+        text:  |
+          Pre-production respondent-home-ui deployment failed. See build:
+          $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+    params:
+      current_app_name: respondent-home-ui-preprod
+      manifest: respondent-home-ui-release-source/manifest.yml
+      path: respondent-home-ui-release-source
+      environment_variables:
+        HOST: 0.0.0.0
+        LOG_LEVEL: INFO
+        ACCOUNT_SERVICE_URL: ((preprod_account_service_url))    # Remember to exclude all path prefixes here
+        EQ_URL: https://eq.onsdigital.uk
+        JSON_SECRET_KEYS: ((preprod_json_secret_keys))
+        CASE_URL: http://casesvc-preprod.((preprod_cloudfoundry_apps_domain))
+        CASE_USERNAME: ((preprod_security_user_name))
+        CASE_PASSWORD: ((preprod_security_user_password))
+        COLLECTION_EXERCISE_URL: http://collectionexercisesvc-preprod.((preprod_cloudfoundry_apps_domain))
+        COLLECTION_EXERCISE_USERNAME: ((preprod_security_user_name))
+        COLLECTION_EXERCISE_PASSWORD: ((preprod_security_user_password))
+        COLLECTION_INSTRUMENT_URL: http://ras-collection-instrument-preprod.((preprod_cloudfoundry_apps_domain))
+        COLLECTION_INSTRUMENT_USERNAME: ((preprod_security_user_name))
+        COLLECTION_INSTRUMENT_PASSWORD: ((preprod_security_user_password))
+        IAC_URL: http://iacsvc-preprod.((preprod_cloudfoundry_apps_domain))
+        IAC_USERNAME: ((preprod_security_user_name))
+        IAC_PASSWORD: ((preprod_security_user_password))
+        PARTY_URL: http://ras-party-service-preprod.((preprod_cloudfoundry_apps_domain))
+        PARTY_USERNAME: ((preprod_security_user_name))
+        PARTY_PASSWORD: ((preprod_security_user_password))
+        SURVEY_URL: http://surveysvc-preprod.((preprod_cloudfoundry_apps_domain))
+        SURVEY_USERNAME: ((preprod_security_user_name))
+        SURVEY_PASSWORD: ((preprod_security_user_password))
+        SAMPLE_URL: http://samplesvc-preprod.((preprod_cloudfoundry_apps_domain))
+        SAMPLE_USERNAME: ((preprod_security_user_name))
+        SAMPLE_PASSWORD: ((preprod_security_user_password))
+        SECRET_KEY: ((preprod_rh_secret_key))
+        URL_PATH_PREFIX: /((preprod_path))
+        ANALYTICS_UA_ID: ((preprod_analytics_ua_id))
+
+  - put: map-route-vpn-domain
+    resource: cf-cli-resource-preprod
+    params:
+      command: map-route
+      app_name: respondent-home-ui-preprod
+      domain: rhpreprod.rmdev.onsdigital.uk
+  - put: map-route-ons-internal-domain
+    resource: cf-cli-resource-preprod
+    params:
+      app_name: respondent-home-ui-preprod
+      command: map-route
+      domain: ohs-alpha.onsdigital.uk
+  - put: map-route-ons-internal-preprod-domain
+    resource: cf-cli-resource-preprod
+    params:
+      app_name: respondent-home-ui-preprod
+      command: map-route
+      domain: ((preprod_domain))
+      path: ((preprod_path))
+  - task: smoke-tests
+    on_failure:
+      put: notify
+      params:
+        text:  |
+          Pre-production smoke tests failed. Check the build:
+          $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+    file: respondent-home-ui-release-source/ci/smoke_tests.yml
     params:
       RESPONDENT_HOME_INTERNAL_URL: https://respondent-home-ui-preprod.((preprod_cloudfoundry_apps_domain))
       RESPONDENT_HOME_URL: https://respondent-home-ui-preprod.((preprod_cloudfoundry_apps_domain))
@@ -216,9 +351,29 @@ jobs:
 - name: respondent-home-ui-prod-deploy
   serial: true
   plan:
-  - get: respondent-home-ui-source
+  - get: respondent-home-ui-release
     passed: [respondent-home-ui-preprod-deploy]
     trigger: true
+    params:
+      include_source_tarball: true
+  - task: extract-release-source
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: alpine
+          tag: latest
+      inputs:
+      - name: respondent-home-ui-release
+      outputs:
+      - name: respondent-home-ui-release-source
+      run:
+        path: sh
+        args:
+        - -exc
+        - |
+          tar -xzf respondent-home-ui-release/source.tar.gz -C respondent-home-ui-release-source --strip-components=1
   - put: push-app
     resource: cf-resource-prod
     on_failure:
@@ -229,8 +384,8 @@ jobs:
           $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
     params:
       current_app_name: respondent-home-ui-prod
-      manifest: respondent-home-ui-source/manifest.yml
-      path: respondent-home-ui-source
+      manifest: respondent-home-ui-release-source/manifest.yml
+      path: respondent-home-ui-release-source
       environment_variables:
         APP_SETTINGS: ProductionConfig
         HOST: 0.0.0.0
@@ -277,7 +432,7 @@ jobs:
         text:  |
           Production smoke tests failed. Check the build:
           $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
-    file: respondent-home-ui-source/ci/smoke_tests.yml
+    file: respondent-home-ui-release-source/ci/smoke_tests.yml
     params:
       RESPONDENT_HOME_INTERNAL_URL: https://respondent-home-ui-prod.((prod_cloudfoundry_apps_domain))
       RESPONDENT_HOME_URL: https://((prod_domain))

--- a/pipelines/respondent-home-ui.yml
+++ b/pipelines/respondent-home-ui.yml
@@ -27,13 +27,13 @@ resources:
 - name: respondent-home-ui-release
   type: github-release
   source:
-    user: ONSdigital
+    owner: ONSdigital
     repository: respondent-home-ui
 
 - name: respondent-home-ui-pre-release
   type: github-release
   source:
-    user: ONSdigital
+    owner: ONSdigital
     repository: respondent-home-ui
     release: false
     pre_release: true

--- a/secrets/respondent-home-ui-vars.yml.example
+++ b/secrets/respondent-home-ui-vars.yml.example
@@ -16,6 +16,9 @@ prod_cloudfoundry_apps_domain:
 # Slack
 slack_webhook:
 
+# Github
+github_access_token: 
+
 # Latest secrets
 latest_security_user_name:
 latest_security_user_password:

--- a/tasks/extract-source-from-release.yml
+++ b/tasks/extract-source-from-release.yml
@@ -1,0 +1,21 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: alpine
+    tag: latest
+
+inputs:
+- name: release-resource
+
+outputs:
+- name: release-source
+
+run:
+  path: sh
+  args:
+  - -exc
+  - |
+    tar -xzf release-resource/source.tar.gz -C release-source --strip-components=1


### PR DESCRIPTION
# Motivation and Context
Up till now respondent home has been continuously deploying from master on commits. Now the service is in use we want to be able to control releases more closely. This PR Changes the preprod and prod deploys to be triggered by and deploy from github releases rather than commits. It also adds a job to deploy to just preprod on pre-releases to allow testing there before the changes are deployed to prod.

# What has changed
* Change trigger and source of preprod and prod deploy jobs to use a github release resource
* Extract and use release tarball for release
* Add pre-release preprod job 
* Use a serial group to stop the two preprod deploys from running simultaneously
* Add the service name to notify messages for clarity
* Added github access token so that the github release resource does not hit rate limits

# How to test?
The pipeline should validate without issues, otherwise flying it will be the only test.

# Links
https://trello.com/c/ALHRQ5b0/310-pause-pipeline-at-pre-prod-and-create-prod-deployment
