### PR TITLE
Response operations social UI deploy on releases

### DIFF
--- a/pipelines/response-operations-social-ui.yml
+++ b/pipelines/response-operations-social-ui.yml
@@ -85,24 +85,10 @@ jobs:
   - get: response-operations-social-ui-pre-release
     trigger: true
   - get: ras-deploy
-  - task: extract-source
-    config:
-      platform: linux
-      image_resource:
-        type: docker-image
-        source:
-          repository: alpine
-          tag: latest
-      inputs:
-      - name: response-operations-social-ui-pre-release
-      outputs:
-      - name: response-operations-social-ui-pre-release-source
-      run:
-        path: sh
-        args:
-        - -exc
-        - |
-          tar -xzf response-operations-social-ui-pre-release/source.tar.gz -C response-operations-social-ui-pre-release-source --strip-components=1
+  - task: extract-source-from-release-tarball
+    file: ras-deploy/tasks/extract-source-from-release.yml
+    input_mapping: { release-resource: response-operations-social-ui-pre-release }
+    output_mapping: { release-source: response-operations-social-ui-pre-release-source }
   - task: run-unit-tests
     file: ras-deploy/tasks/python-unit-tests.yml
     input_mapping: { repository-name: response-operations-social-ui-pre-release-source }
@@ -171,24 +157,10 @@ jobs:
   - get: response-operations-social-ui-release
     trigger: true
   - get: ras-deploy
-  - task: extract-source
-    config:
-      platform: linux
-      image_resource:
-        type: docker-image
-        source:
-          repository: alpine
-          tag: latest
-      inputs:
-      - name: response-operations-social-ui-release
-      outputs:
-      - name: response-operations-social-ui-release-source
-      run:
-        path: sh
-        args:
-        - -exc
-        - |
-          tar -xzf response-operations-social-ui-release/source.tar.gz -C response-operations-social-ui-release-source --strip-components=1
+  - task: extract-source-from-release-tarball
+    file: ras-deploy/tasks/extract-source-from-release.yml
+    input_mapping: { release-resource: response-operations-social-ui-release }
+    output_mapping: { release-source: response-operations-social-ui-release-source }
   - task: run-unit-tests
     file: ras-deploy/tasks/python-unit-tests.yml
     input_mapping: { repository-name: response-operations-social-ui-release-source }
@@ -257,24 +229,10 @@ jobs:
     passed: [response-operations-social-ui-preprod-deploy]
     trigger: true
   - get: ras-deploy
-  - task: extract-source
-    config:
-      platform: linux
-      image_resource:
-        type: docker-image
-        source:
-          repository: alpine
-          tag: latest
-      inputs:
-      - name: response-operations-social-ui-release
-      outputs:
-      - name: response-operations-social-ui-release-source
-      run:
-        path: sh
-        args:
-        - -exc
-        - |
-          tar -xzf response-operations-social-ui-release/source.tar.gz -C response-operations-social-ui-release-source --strip-components=1
+  - task: extract-source-from-release-tarball
+    file: ras-deploy/tasks/extract-source-from-release.yml
+    input_mapping: { release-resource: response-operations-social-ui-release }
+    output_mapping: { release-source: response-operations-social-ui-release-source }
   - task: run-unit-tests
     file: ras-deploy/tasks/python-unit-tests.yml
     input_mapping: { repository-name: response-operations-social-ui-release-source }

--- a/pipelines/response-operations-social-ui.yml
+++ b/pipelines/response-operations-social-ui.yml
@@ -21,7 +21,7 @@ resources:
 - name: response-operations-social-ui-pre-release
   type: github-release
   source:
-    user: ONSdigital
+    owner: ONSdigital
     repository: response-operations-social-ui
     release: false
     pre_release: true
@@ -29,7 +29,7 @@ resources:
 - name: response-operations-social-ui-release
   type: github-release
   source:
-    user: ONSdigital
+    owner: ONSdigital
     repository: response-operations-social-ui
 
 - name: cf-resource-preprod

--- a/pipelines/response-operations-social-ui.yml
+++ b/pipelines/response-operations-social-ui.yml
@@ -12,17 +12,25 @@ resource_types:
     tag: latest
 
 resources:
-- name: response-operations-social-ui-source
-  type: git
-  source:
-    uri: https://github.com/ONSdigital/response-operations-social-ui.git
-    branch: master
-
 - name: ras-deploy
   type: git
   source:
     uri: https://github.com/ONSdigital/ras-deploy.git
     branch: master
+
+- name: response-operations-social-ui-pre-release
+  type: github-release
+  source:
+    user: ONSdigital
+    repository: response-operations-social-ui
+    release: false
+    pre_release: true
+
+- name: response-operations-social-ui-release
+  type: github-release
+  source:
+    user: ONSdigital
+    repository: response-operations-social-ui
 
 - name: cf-resource-preprod
   type: cf
@@ -70,15 +78,120 @@ resources:
     url: ((slack_webhook))
 
 jobs:
-- name: response-operations-social-ui-preprod-deploy
+- name: response-operations-social-ui-preprod-pre-release-deploy
   serial: true
+  serial_groups: [preprod_deploys]
   plan:
-  - get: response-operations-social-ui-source
+  - get: response-operations-social-ui-pre-release
     trigger: true
   - get: ras-deploy
+  - task: extract-source
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: alpine
+          tag: latest
+      inputs:
+      - name: response-operations-social-ui-pre-release
+      outputs:
+      - name: response-operations-social-ui-pre-release-source
+      run:
+        path: sh
+        args:
+        - -exc
+        - |
+          tar -xzf response-operations-social-ui-pre-release/source.tar.gz -C response-operations-social-ui-pre-release-source --strip-components=1
   - task: run-unit-tests
     file: ras-deploy/tasks/python-unit-tests.yml
-    input_mapping: { repository-name: response-operations-social-ui-source }
+    input_mapping: { repository-name: response-operations-social-ui-pre-release-source }
+    on_failure:
+      put: notify
+      params:
+        text:  |
+          Pre-production pre-release response-operations-social-ui unit tests failed. See build:
+          $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+  - put: create-redis
+    resource: cf-cli-resource-preprod
+    params:
+      command: create-service
+      service: awselasticache-redis
+      plan: small
+      service_instance: res-ops-redis
+      timeout: 1800
+      wait_for_service: true
+  - put: push-app
+    resource: cf-resource-preprod
+    on_failure:
+      put: notify
+      params:
+        text:  |
+          Pre-production pre-release response-operations-social-ui deployment failed. See build:
+          $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+    params:
+      current_app_name: response-operations-social-ui-preprod
+      manifest: response-operations-social-ui-pre-release-source/manifests/manifest-prod.yml
+      path: response-operations-social-ui-pre-release-source
+      environment_variables:
+        APP_SETTINGS: Config
+        CASE_URL: http://casesvc-preprod.((preprod_cloudfoundry_apps_domain))
+        IAC_URL: http://iacsvc-preprod.((preprod_cloudfoundry_apps_domain))
+        SAMPLE_URL: http://samplesvc-preprod.((preprod_cloudfoundry_apps_domain))
+        REPORT_URL: http://rm-reporting-preprod.((preprod_cloudfoundry_apps_domain))
+        UAA_SERVICE_URL: http://uaa-preprod.((preprod_cloudfoundry_apps_domain))
+        UAA_CLIENT_ID: 'response_operations_social'
+        UAA_CLIENT_SECRET: ((preprod_response_operations_social_client_secret))
+        CASE_USERNAME: ((preprod_security_user_name))
+        CASE_PASSWORD: ((preprod_security_user_password))
+        IAC_USERNAME: ((preprod_security_user_name))
+        IAC_PASSWORD: ((preprod_security_user_password))
+        SAMPLE_USERNAME: ((preprod_security_user_name))
+        SAMPLE_PASSWORD: ((preprod_security_user_password))
+        SECURITY_USER_NAME: ((preprod_security_user_name))
+        SECURITY_USER_PASSWORD: ((preprod_security_user_password))
+        REDIS_SERVICE: res-ops-redis
+  - put: map-route-vpn-domain
+    resource: cf-cli-resource-preprod
+    params:
+      command: map-route
+      app_name: response-operations-social-ui-preprod
+      domain: ((preprod_vpn_domain))
+  - put: map-route-internal-domain
+    resource: cf-cli-resource-preprod
+    params:
+      command: map-route
+      app_name: response-operations-social-ui-preprod
+      domain: ((preprod_internal_domain))
+
+- name: response-operations-social-ui-preprod-deploy
+  serial: true
+  serial_groups: [preprod_deploys]
+  plan:
+  - get: response-operations-social-ui-release
+    trigger: true
+  - get: ras-deploy
+  - task: extract-source
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: alpine
+          tag: latest
+      inputs:
+      - name: response-operations-social-ui-release
+      outputs:
+      - name: response-operations-social-ui-release-source
+      run:
+        path: sh
+        args:
+        - -exc
+        - |
+          tar -xzf response-operations-social-ui-release/source.tar.gz -C response-operations-social-ui-release-source --strip-components=1
+  - task: run-unit-tests
+    file: ras-deploy/tasks/python-unit-tests.yml
+    input_mapping: { repository-name: response-operations-social-ui-release-source }
     on_failure:
       put: notify
       params:
@@ -104,8 +217,8 @@ jobs:
           $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
     params:
       current_app_name: response-operations-social-ui-preprod
-      manifest: response-operations-social-ui-source/manifests/manifest-prod.yml
-      path: response-operations-social-ui-source
+      manifest: response-operations-social-ui-release-source/manifests/manifest-prod.yml
+      path: response-operations-social-ui-release-source
       environment_variables:
         APP_SETTINGS: Config
         CASE_URL: http://casesvc-preprod.((preprod_cloudfoundry_apps_domain))
@@ -140,13 +253,31 @@ jobs:
 - name: response-operations-social-ui-prod-deploy
   serial: true
   plan:
-  - get: response-operations-social-ui-source
+  - get: response-operations-social-ui-release
     passed: [response-operations-social-ui-preprod-deploy]
     trigger: true
   - get: ras-deploy
+  - task: extract-source
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: alpine
+          tag: latest
+      inputs:
+      - name: response-operations-social-ui-release
+      outputs:
+      - name: response-operations-social-ui-release-source
+      run:
+        path: sh
+        args:
+        - -exc
+        - |
+          tar -xzf response-operations-social-ui-release/source.tar.gz -C response-operations-social-ui-release-source --strip-components=1
   - task: run-unit-tests
     file: ras-deploy/tasks/python-unit-tests.yml
-    input_mapping: { repository-name: response-operations-social-ui-source }
+    input_mapping: { repository-name: response-operations-social-ui-release-source }
     on_failure:
       put: notify
       params:
@@ -172,8 +303,8 @@ jobs:
           $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
     params:
       current_app_name: response-operations-social-ui-prod
-      manifest: response-operations-social-ui-source/manifests/manifest-prod.yml
-      path: response-operations-social-ui-source
+      manifest: response-operations-social-ui-release-source/manifests/manifest-prod.yml
+      path: response-operations-social-ui-release-source
       environment_variables:
         APP_SETTINGS: Config
         CASE_URL: http://casesvc-prod.((prod_cloudfoundry_apps_domain))

--- a/pipelines/response-operations-social-ui.yml
+++ b/pipelines/response-operations-social-ui.yml
@@ -84,6 +84,8 @@ jobs:
   plan:
   - get: response-operations-social-ui-pre-release
     trigger: true
+    params:
+      include_source_tarball: true
   - get: ras-deploy
   - task: extract-source-from-release-tarball
     file: ras-deploy/tasks/extract-source-from-release.yml
@@ -156,6 +158,8 @@ jobs:
   plan:
   - get: response-operations-social-ui-release
     trigger: true
+    params:
+      include_source_tarball: true
   - get: ras-deploy
   - task: extract-source-from-release-tarball
     file: ras-deploy/tasks/extract-source-from-release.yml
@@ -228,6 +232,8 @@ jobs:
   - get: response-operations-social-ui-release
     passed: [response-operations-social-ui-preprod-deploy]
     trigger: true
+    params:
+      include_source_tarball: true
   - get: ras-deploy
   - task: extract-source-from-release-tarball
     file: ras-deploy/tasks/extract-source-from-release.yml

--- a/pipelines/response-operations-social-ui.yml
+++ b/pipelines/response-operations-social-ui.yml
@@ -23,6 +23,7 @@ resources:
   source:
     owner: ONSdigital
     repository: response-operations-social-ui
+    access_token: ((github_access_token))
     release: false
     pre_release: true
 
@@ -31,6 +32,7 @@ resources:
   source:
     owner: ONSdigital
     repository: response-operations-social-ui
+    access_token: ((github_access_token))
 
 - name: cf-resource-preprod
   type: cf

--- a/secrets/response-operations-social-ui.yml.example
+++ b/secrets/response-operations-social-ui.yml.example
@@ -30,3 +30,6 @@ prod_internal_domain:
 
 # Slack
 slack_webhook:
+
+# Github
+github_access_token:

--- a/tasks/extract-source-from-release.yml
+++ b/tasks/extract-source-from-release.yml
@@ -1,15 +1,19 @@
 ---
 platform: linux
- image_resource:
+
+image_resource:
   type: docker-image
   source:
     repository: alpine
     tag: latest
- inputs:
+
+inputs:
 - name: release-resource
- outputs:
+
+outputs:
 - name: release-source
- run:
+
+run:
   path: sh
   args:
   - -exc

--- a/tasks/extract-source-from-release.yml
+++ b/tasks/extract-source-from-release.yml
@@ -1,0 +1,17 @@
+---
+platform: linux
+ image_resource:
+  type: docker-image
+  source:
+    repository: alpine
+    tag: latest
+ inputs:
+- name: release-resource
+ outputs:
+- name: release-source
+ run:
+  path: sh
+  args:
+  - -exc
+  - |
+    tar -xzf release-resource/source.tar.gz -C release-source --strip-components=1


### PR DESCRIPTION
# Motivation and Context
Up till now response-operations-social-ui has been continuously deploying from master on commits. Now the service is in use we want to be able to control releases more closely. This PR Changes the preprod and prod deploys to be triggered by and deploy from github releases rather than commits. It also adds a job to deploy to just preprod on pre-releases to allow testing there before the changes are deployed to prod.

# What has changed
* Change trigger and source of preprod and prod deploy jobs to use a github release resource
* Extract and use release tarball for release
* Add pre-release preprod job
* Use a serial group to stop the two preprod deploys from running simultaneously
* Added github access token so that the github release resource does not hit rate limits

# How to test?
Check all the resources and jobs makes sense. The response-operations-social-ui pipeline has been flown from this branch and successfully run a pre-release deploy job into preprod.

# Links
https://trello.com/c/ALHRQ5b0/310-pause-pipeline-at-pre-prod-and-create-prod-deployment
