### PR TITLE
Add retry mechansim and return error code if we fail to get a DB URI

### DIFF
--- a/scripts/get_database_uris.sh
+++ b/scripts/get_database_uris.sh
@@ -3,8 +3,34 @@ set -e
 
 cf login -a "$CLOUDFOUNDRY_API" -u "$CLOUDFOUNDRY_EMAIL" -p "$CLOUDFOUNDRY_PASSWORD" -o "$CLOUDFOUNDRY_ORG" -s "$CLOUDFOUNDRY_SPACE" --skip-ssl-validation >/dev/null
 
-echo "export DATABASE_URI=$(cf apps | grep rm-case-service-"$CLOUDFOUNDRY_SPACE" | awk '{ print "cf env "$1 }'| bash | grep "postgres://" | awk -F \" '{ print $4 }')"
-echo "export PARTY_DATABASE_URI=$(cf apps | grep ras-party-"$CLOUDFOUNDRY_SPACE" | awk '{ print "cf env "$1 }'| bash | grep "postgres://" | awk -F \" '{ print $4 }')"
-echo "export AUTH_DATABASE_URI=$(cf apps | grep ras-rm-auth-service-"$CLOUDFOUNDRY_SPACE" | awk '{ print "cf env "$1 }'| bash | grep "postgres://" | awk -F \" '{ print $4 }')"
-echo "export SECURE_MESSAGE_DATABASE_URI=$(cf apps | grep ras-secure-message-"$CLOUDFOUNDRY_SPACE" | awk '{ print "cf env "$1 }'| bash | grep "postgres://" | awk -F \" '{ print $4 }')"
-echo "export COLLECTION_INSTRUMENT_DATABASE_URI=$(cf apps | grep ras-collection-instrument-"$CLOUDFOUNDRY_SPACE" | awk '{ print "cf env "$1 }'| bash | grep "postgres://" | awk -F \" '{ print $4 }')"
+retry_setup_env_var () {
+  counter=1
+  while [ 1 ]
+  do
+    EXPORT_VARIABLE=$1
+    SERVICE_PREFIX=$2
+      
+    GET_URI_RESULT=$(cf apps | grep $SERVICE_PREFIX"$CLOUDFOUNDRY_SPACE" | awk '{ print "cf env "$1 }'| bash | grep "postgres://" | awk -F \" '{ print $4 }')
+    
+    stringlen=$(printf "%s" "$GET_URI_RESULT" | wc -c)
+    if [ $stringlen -gt 0 ]
+    then
+      echo "export $EXPORT_VARIABLE=$GET_URI_RESULT"
+      break
+    fi
+    
+    if [ $counter -gt 3 ]
+    then
+      exit 1
+    fi
+
+    ((counter++))
+    sleep 10
+  done
+}
+
+retry_setup_env_var DATABASE_URI rm-case-service-
+retry_setup_env_var PARTY_DATABASE_URI ras-party-
+retry_setup_env_var DJANGO_OAUTH_DATABASE_URI django-oauth2-test-
+retry_setup_env_var SECURE_MESSAGE_DATABASE_URI ras-secure-message-
+retry_setup_env_var COLLECTION_INSTRUMENT_DATABASE_URI ras-collection-instrument-


### PR DESCRIPTION
# Motivation and Context
We are seeing failures regularly in the Concourse CI pipeline where we are failing to set one of the DB URI env variables, perhaps due to one of the commands failing but the error being swallowed.

Example: https://concourse.onsdigital.uk/teams/rmras/pipelines/rasrm/jobs/ci-rasrm-acceptance-tests/builds/912

# What has changed
Added a function which checks that the URI length is greater than zero and retries 3 times, with a 10 second delay, in the event that Cloud Foundry isn't giving us the environment variable that we expect to find.

In the instance that the DB URI cannot be retrieved within the 30 seconds, an error code is returned which should fail the Concourse build on the step `get-cf-database-uris` instead of throwing a misleading error later on in the build.

# How to test?
You can run the script locally if you comment out line 4. Try running it logged into Cloud Foundry and not logged in.

# Links
Trello: https://trello.com/c/mIuLupy6/555-bug-concourse-build-fails-occasionally-because-setup-script-to-get-db-uris-does-not-throw-any-errors
Example failure: https://concourse.onsdigital.uk/teams/rmras/pipelines/rasrm/jobs/ci-rasrm-acceptance-tests/builds/912
