### PR TITLE
Fix auth database URI variable name in get database URI script

### DIFF
--- a/scripts/get_database_uris.sh
+++ b/scripts/get_database_uris.sh
@@ -9,16 +9,16 @@ retry_setup_env_var () {
   do
     EXPORT_VARIABLE=$1
     SERVICE_PREFIX=$2
-      
+
     GET_URI_RESULT=$(cf apps | grep $SERVICE_PREFIX"$CLOUDFOUNDRY_SPACE" | awk '{ print "cf env "$1 }'| bash | grep "postgres://" | awk -F \" '{ print $4 }')
-    
+
     stringlen=$(printf "%s" "$GET_URI_RESULT" | wc -c)
     if [ $stringlen -gt 0 ]
     then
       echo "export $EXPORT_VARIABLE=$GET_URI_RESULT"
       break
     fi
-    
+
     if [ $counter -gt 3 ]
     then
       exit 1
@@ -31,6 +31,6 @@ retry_setup_env_var () {
 
 retry_setup_env_var DATABASE_URI rm-case-service-
 retry_setup_env_var PARTY_DATABASE_URI ras-party-
-retry_setup_env_var DJANGO_OAUTH_DATABASE_URI django-oauth2-test-
+retry_setup_env_var AUTH_DATABASE_URI django-oauth2-test-
 retry_setup_env_var SECURE_MESSAGE_DATABASE_URI ras-secure-message-
 retry_setup_env_var COLLECTION_INSTRUMENT_DATABASE_URI ras-collection-instrument-


### PR DESCRIPTION
# Motivation and Context
Reverts change of variable name in https://github.com/ONSdigital/ras-deploy/pull/96 which caused the pipeline to fail

# What has changed
* Fix auth database uri variable name in get database uri script

# How to test?
Check this change matches the original variable name and what the clean up scripts are expecting.

# Links
https://github.com/ONSdigital/ras-deploy/pull/96
