### PR TITLE
Responses Dashboard: Deploy from releases

### DIFF
--- a/pipelines/sdc-responses-dashboard.yml
+++ b/pipelines/sdc-responses-dashboard.yml
@@ -23,6 +23,22 @@ resources:
     uri: https://github.com/ONSdigital/ras-deploy.git
     branch: master
 
+- name: sdc-responses-dashboard-release
+  type: github-release
+  source:
+    owner: ONSdigital
+    repository: sdc-responses-dashboard
+    access_token: ((github_access_token))
+
+- name: sdc-responses-dashboard-pre-release
+  type: github-release
+  source:
+    owner: ONSdigital
+    repository: sdc-responses-dashboard
+    access_token: ((github_access_token))
+    release: false
+    pre_release: true
+
 - name: cf-resource-latest
   type: cf
   source:
@@ -112,15 +128,70 @@ jobs:
         Devtest Latest space responses-dashboard deploy failed. See build:
         $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
 
+- name: sdc-responses-dashboard-preprod-pre-release-deploy
+  serial: true
+  serial_groups: [preprod_deploys]
+  plan:
+  - get: sdc-responses-dashboard-pre-release
+    trigger: true
+  - get: ras-deploy
+  - task: extract-source-from-release-tarball
+    file: ras-deploy/tasks/extract-source-from-release.yml
+    input_mapping: { release-resource: sdc-responses-dashboard-pre-release }
+    output_mapping: { release-source: sdc-responses-dashboard-release-source }
+  - task: run-yarn-compile
+    file: sdc-responses-dashboard-release-source/yarn-compile-task.yml
+    input_mapping: { sdc-responses-dashboard-source: sdc-responses-dashboard-release-source }
+  - put: push-app
+    resource: cf-resource-preprod
+    params:
+      current_app_name: sdc-responses-dashboard-preprod
+      manifest: compiled-sdc-responses-dashboard-source/manifest.yml
+      path: compiled-sdc-responses-dashboard-source
+      environment_variables:
+        HOST: 0.0.0.0
+        LOGGING_LEVEL: DEBUG
+        REPORTING_REFRESH_CYCLE_IN_SECONDS: "600"
+        COLLECTION_EXERCISE_URL: http://collectionexercisesvc-preprod.((preprod_cloudfoundry_apps_domain))
+        SURVEY_URL: http://surveysvc-preprod.((preprod_cloudfoundry_apps_domain))
+        REPORTING_URL: http://rm-reporting-preprod.((preprod_cloudfoundry_apps_domain))
+        AUTH_USERNAME: ((preprod_security_user_name))
+        AUTH_PASSWORD: ((preprod_security_user_password))
+  - put: map-route-ons-internal-domain
+    resource: cf-cli-resource-preprod
+    params:
+      command: map-route
+      app_name: sdc-responses-dashboard-preprod
+      domain: ((preprod_internal_domain))
+      path: dashboard
+  - put: map-route-ons-vpn-domain
+    resource: cf-cli-resource-preprod
+    params:
+      command: map-route
+      app_name: sdc-responses-dashboard-preprod
+      domain: ((preprod_vpn_domain))
+      path: dashboard
+  on_failure:
+    put: notify
+    params:
+      text:  |
+        Preprod responses-dashboard deploy failed. See build:
+        $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
 
 - name: sdc-responses-dashboard-preprod-deploy
   serial: true
+  serial_groups: [preprod_deploys]
   plan:
-  - get: sdc-responses-dashboard-source
-    passed: [sdc-responses-dashboard-latest-deploy]
+  - get: sdc-responses-dashboard-release
     trigger: true
+  - get: ras-deploy
+  - task: extract-source-from-release-tarball
+    file: ras-deploy/tasks/extract-source-from-release.yml
+    input_mapping: { release-resource: sdc-responses-dashboard-release }
+    output_mapping: { release-source: sdc-responses-dashboard-release-source }
   - task: run-yarn-compile
-    file: sdc-responses-dashboard-source/yarn-compile-task.yml
+    file: sdc-responses-dashboard-release-source/yarn-compile-task.yml
+    input_mapping: { sdc-responses-dashboard-source: sdc-responses-dashboard-release-source }
   - put: push-app
     resource: cf-resource-preprod
     params:
@@ -160,11 +231,17 @@ jobs:
 - name: sdc-responses-dashboard-prod-deploy
   serial: true
   plan:
-  - get: sdc-responses-dashboard-source
+  - get: sdc-responses-dashboard-release
     passed: [sdc-responses-dashboard-preprod-deploy]
     trigger: true
+  - get: ras-deploy
+  - task: extract-source-from-release-tarball
+    file: ras-deploy/tasks/extract-source-from-release.yml
+    input_mapping: { release-resource: sdc-responses-dashboard-release }
+    output_mapping: { release-source: sdc-responses-dashboard-release-source }
   - task: run-yarn-compile
     file: sdc-responses-dashboard-source/yarn-compile-task.yml
+    input_mapping: { sdc-responses-dashboard-source: sdc-responses-dashboard-release-source }
   - put: push-app
     resource: cf-resource-prod
     params:

--- a/pipelines/sdc-responses-dashboard.yml
+++ b/pipelines/sdc-responses-dashboard.yml
@@ -246,7 +246,7 @@ jobs:
     input_mapping: { release-resource: sdc-responses-dashboard-release }
     output_mapping: { release-source: sdc-responses-dashboard-release-source }
   - task: run-yarn-compile
-    file: sdc-responses-dashboard-source/yarn-compile-task.yml
+    file: sdc-responses-dashboard-release-source/yarn-compile-task.yml
     input_mapping: { sdc-responses-dashboard-source: sdc-responses-dashboard-release-source }
   - put: push-app
     resource: cf-resource-prod

--- a/pipelines/sdc-responses-dashboard.yml
+++ b/pipelines/sdc-responses-dashboard.yml
@@ -134,6 +134,8 @@ jobs:
   plan:
   - get: sdc-responses-dashboard-pre-release
     trigger: true
+    params:
+      include_source_tarball: true
   - get: ras-deploy
   - task: extract-source-from-release-tarball
     file: ras-deploy/tasks/extract-source-from-release.yml
@@ -184,6 +186,8 @@ jobs:
   plan:
   - get: sdc-responses-dashboard-release
     trigger: true
+    params:
+      include_source_tarball: true
   - get: ras-deploy
   - task: extract-source-from-release-tarball
     file: ras-deploy/tasks/extract-source-from-release.yml
@@ -234,6 +238,8 @@ jobs:
   - get: sdc-responses-dashboard-release
     passed: [sdc-responses-dashboard-preprod-deploy]
     trigger: true
+    params:
+      include_source_tarball: true
   - get: ras-deploy
   - task: extract-source-from-release-tarball
     file: ras-deploy/tasks/extract-source-from-release.yml

--- a/pipelines/sdc-responses-dashboard.yml
+++ b/pipelines/sdc-responses-dashboard.yml
@@ -85,15 +85,17 @@ jobs:
   - get: sdc-responses-dashboard-source
     trigger: true
   - get: ras-deploy
+  - task: run-yarn-compile
+    file: sdc-responses-dashboard-source/yarn-compile-task.yml
   - task: run-unit-tests
     file: ras-deploy/tasks/python-unit-tests.yml
-    input_mapping: { repository-name: sdc-responses-dashboard-source }
+    input_mapping: { repository-name: compiled-sdc-responses-dashboard-source }
   - put: push-app
     resource: cf-resource-latest
     params:
       current_app_name: sdc-responses-dashboard-latest
-      manifest: sdc-responses-dashboard-source/manifest.yml
-      path: sdc-responses-dashboard-source
+      manifest: compiled-sdc-responses-dashboard-source/manifest.yml
+      path: compiled-sdc-responses-dashboard-source
       environment_variables:
         HOST: 0.0.0.0
         LOGGING_LEVEL: DEBUG
@@ -117,13 +119,14 @@ jobs:
   - get: sdc-responses-dashboard-source
     passed: [sdc-responses-dashboard-latest-deploy]
     trigger: true
-  - get: ras-deploy
+  - task: run-yarn-compile
+    file: sdc-responses-dashboard-source/yarn-compile-task.yml
   - put: push-app
     resource: cf-resource-preprod
     params:
       current_app_name: sdc-responses-dashboard-preprod
-      manifest: sdc-responses-dashboard-source/manifest.yml
-      path: sdc-responses-dashboard-source
+      manifest: compiled-sdc-responses-dashboard-source/manifest.yml
+      path: compiled-sdc-responses-dashboard-source
       environment_variables:
         HOST: 0.0.0.0
         LOGGING_LEVEL: DEBUG
@@ -160,13 +163,14 @@ jobs:
   - get: sdc-responses-dashboard-source
     passed: [sdc-responses-dashboard-preprod-deploy]
     trigger: true
-  - get: ras-deploy
+  - task: run-yarn-compile
+    file: sdc-responses-dashboard-source/yarn-compile-task.yml
   - put: push-app
     resource: cf-resource-prod
     params:
       current_app_name: sdc-responses-dashboard-prod
-      manifest: sdc-responses-dashboard-source/manifest.yml
-      path: sdc-responses-dashboard-source
+      manifest: compiled-sdc-responses-dashboard-source/manifest.yml
+      path: compiled-sdc-responses-dashboard-source
       environment_variables:
         HOST: 0.0.0.0
         LOGGING_LEVEL: DEBUG

--- a/secrets/sdc-responses-dashboard.yml.example
+++ b/secrets/sdc-responses-dashboard.yml.example
@@ -34,4 +34,7 @@ prod_vpn_domain:
 prod_internal_domain:
 
 # Slack Notify
-slack_webhook: 
+slack_webhook:
+
+# Github Access
+github_access_token:


### PR DESCRIPTION
# Motivation and Context
Deploy responses dashboard to preprod/prod from Github release tags rather than commits to master

# What has changed
- Changed preprod and prod release jobs to use github releases
- Added preprod pre-release deploy job
- Added task step to run yarn compile task
- Changed deployed resource to the compiled source
- Update example secrets

# How to test?
The pipeline has been flown and successfully deployed the dashboard through preprod and prod off of a release tag

# Links
https://github.com/ONSdigital/sdc-responses-dashboard/pull/52
https://trello.com/c/opD7Vun5/85-enable-babel-js-to-allows-for-backwards-compatibility
https://trello.com/c/WnzA4ysT/99-altering-pipeline-to-use-release-tags-from-github
