### PR TITLE
Fix input mapping for smoke test task in respondent-home-ui deploy jobs

### DIFF
--- a/pipelines/respondent-home-ui.yml
+++ b/pipelines/respondent-home-ui.yml
@@ -236,7 +236,8 @@ jobs:
         text:  |
           Pre-production respondent-home-ui smoke tests failed. Check the build:
           $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
-    file: respondent-home-ui-release-source/ci/smoke_tests.yml
+    file: respondent-home-ui-pre-release-source/ci/smoke_tests.yml
+    input_mapping: { respondent-home-ui-source: respondent-home-ui-pre-release-source }
     params:
       RESPONDENT_HOME_INTERNAL_URL: https://respondent-home-ui-preprod.((preprod_cloudfoundry_apps_domain))
       RESPONDENT_HOME_URL: https://respondent-home-ui-preprod.((preprod_cloudfoundry_apps_domain))
@@ -325,6 +326,7 @@ jobs:
           Pre-production respondent-home-ui smoke tests failed. Check the build:
           $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
     file: respondent-home-ui-release-source/ci/smoke_tests.yml
+    input_mapping: { respondent-home-ui-source: respondent-home-ui-release-source }
     params:
       RESPONDENT_HOME_INTERNAL_URL: https://respondent-home-ui-preprod.((preprod_cloudfoundry_apps_domain))
       RESPONDENT_HOME_URL: https://respondent-home-ui-preprod.((preprod_cloudfoundry_apps_domain))
@@ -402,6 +404,7 @@ jobs:
           Production respondent-home-ui smoke tests failed. Check the build:
           $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
     file: respondent-home-ui-release-source/ci/smoke_tests.yml
+    input_mapping: { respondent-home-ui-source: respondent-home-ui-release-source }
     params:
       RESPONDENT_HOME_INTERNAL_URL: https://respondent-home-ui-prod.((prod_cloudfoundry_apps_domain))
       RESPONDENT_HOME_URL: https://((prod_domain))


### PR DESCRIPTION
# Motivation and Context
The respondent-home-ui pipeline is throwing errors on the deployment smoke tests because the inputs for the task aren't mapped properly.

# What has changed
- Fix resource name in preprod pre-release smoke test task
- Add input mappings for smoke tests in all deploy jobs

# How to test?
Check manually and validate the pipeline. The smoke test tasks in the deploy jobs should now have input mappings which match the inputs in the smoke test task in the RH repo: https://github.com/ONSdigital/respondent-home-ui/blob/master/ci/smoke_tests.yml

This change has been flown and successfully ran a preprod pre-release deploy.

# Links
https://trello.com/c/ALHRQ5b0/310-pause-pipeline-at-pre-prod-and-create-prod-deployment
https://trello.com/c/0vCIb3o8/379-bug379-respondent-home-concourse-smoke-tests-error
