### PR TITLE
Remove broken task no longer needed in deprecated component

### DIFF
--- a/pipelines/deployment.yml
+++ b/pipelines/deployment.yml
@@ -1214,40 +1214,6 @@ jobs:
       service_instance: oauth-db
       timeout: 300
       wait_for_service: true
-  # Create git_info file for info end point
-  - task: git-info
-    config:
-      platform: linux
-      image_resource:
-        type: docker-image
-        source:
-          repository: paasmule/curl-ssl-git
-          tag: "latest"
-      inputs:
-        - name: django-oauth2-test-source
-      outputs:
-        - name: django-oauth2-test-source-git-info
-      run:
-        path: sh
-        args:
-        - -exc
-        - |
-          cd django-oauth2-test-source
-          branch=$(git rev-parse --abbrev-ref HEAD)
-          url=$(git config --get remote.origin.url)
-          commit=$(git rev-parse HEAD)
-          repo=$(basename `git rev-parse --show-toplevel`)
-          when=`date --utc +%FT%TZ`
-          output=git_info
-          echo '{' > ${output}
-          echo   \"origin\": \"${url}\", >> ${output}
-          echo   \"commit\": \"${commit}\", >> ${output}
-          echo   \"branch\": \"${branch}\", >> ${output}
-          echo   \"name\": \"${repo}\", >> ${output}
-          echo   \"built\": \"${when}\" >> ${output}
-          echo '}' >> ${output}
-          cd ..
-          cp -r django-oauth2-test-source/* django-oauth2-test-source-git-info
   - put: cf-resource-ci
     params:
       current_app_name: django-oauth2-test-ci

--- a/pipelines/deployment.yml
+++ b/pipelines/deployment.yml
@@ -2149,40 +2149,6 @@ jobs:
       service_instance: oauth-db
       timeout: 300
       wait_for_service: true
-  # Create git_info file for info end point
-  - task: git-info
-    config:
-      platform: linux
-      image_resource:
-        type: docker-image
-        source:
-          repository: paasmule/curl-ssl-git
-          tag: "latest"
-      inputs:
-        - name: django-oauth2-test-source
-      outputs:
-        - name: django-oauth2-test-source-git-info
-      run:
-        path: sh
-        args:
-        - -exc
-        - |
-          cd django-oauth2-test-source
-          branch=$(git rev-parse --abbrev-ref HEAD)
-          url=$(git config --get remote.origin.url)
-          commit=$(git rev-parse HEAD)
-          repo=$(basename `git rev-parse --show-toplevel`)
-          when=`date --utc +%FT%TZ`
-          output=git_info
-          echo '{' > ${output}
-          echo   \"origin\": \"${url}\", >> ${output}
-          echo   \"commit\": \"${commit}\", >> ${output}
-          echo   \"branch\": \"${branch}\", >> ${output}
-          echo   \"name\": \"${repo}\", >> ${output}
-          echo   \"built\": \"${when}\" >> ${output}
-          echo '}' >> ${output}
-          cd ..
-          cp -r django-oauth2-test-source/* django-oauth2-test-source-git-info
   - put: cf-resource-latest
     params:
       current_app_name: django-oauth2-test-concourse-latest
@@ -2995,40 +2961,6 @@ disabled-jobs:
       service_instance: oauth-db
       timeout: 300
       wait_for_service: true
-  # Create git_info file for info end point
-  - task: git-info
-    config:
-      platform: linux
-      image_resource:
-        type: docker-image
-        source:
-          repository: paasmule/curl-ssl-git
-          tag: "latest"
-      inputs:
-        - name: django-oauth2-test-source
-      outputs:
-        - name: django-oauth2-test-source-git-info
-      run:
-        path: sh
-        args:
-        - -exc
-        - |
-          cd django-oauth2-test-source
-          branch=$(git rev-parse --abbrev-ref HEAD)
-          url=$(git config --get remote.origin.url)
-          commit=$(git rev-parse HEAD)
-          repo=$(basename `git rev-parse --show-toplevel`)
-          when=`date --utc +%FT%TZ`
-          output=git_info
-          echo '{' > ${output}
-          echo   \"origin\": \"${url}\", >> ${output}
-          echo   \"commit\": \"${commit}\", >> ${output}
-          echo   \"branch\": \"${branch}\", >> ${output}
-          echo   \"name\": \"${repo}\", >> ${output}
-          echo   \"built\": \"${when}\" >> ${output}
-          echo '}' >> ${output}
-          cd ..
-          cp -r django-oauth2-test-source/* django-oauth2-test-source-git-info
   - put: cf-resource-preprod
     params:
       current_app_name: django-oauth2-test-concourse-preprod
@@ -3763,40 +3695,6 @@ disabled-jobs:
       service_instance: oauth-db
       timeout: 300
       wait_for_service: true
-  # Create git_info file for info end point
-  - task: git-info
-    config:
-      platform: linux
-      image_resource:
-        type: docker-image
-        source:
-          repository: paasmule/curl-ssl-git
-          tag: "latest"
-      inputs:
-        - name: django-oauth2-test-source
-      outputs:
-        - name: django-oauth2-test-source-git-info
-      run:
-        path: sh
-        args:
-        - -exc
-        - |
-          cd django-oauth2-test-source
-          branch=$(git rev-parse --abbrev-ref HEAD)
-          url=$(git config --get remote.origin.url)
-          commit=$(git rev-parse HEAD)
-          repo=$(basename `git rev-parse --show-toplevel`)
-          when=`date --utc +%FT%TZ`
-          output=git_info
-          echo '{' > ${output}
-          echo   \"origin\": \"${url}\", >> ${output}
-          echo   \"commit\": \"${commit}\", >> ${output}
-          echo   \"branch\": \"${branch}\", >> ${output}
-          echo   \"name\": \"${repo}\", >> ${output}
-          echo   \"built\": \"${when}\" >> ${output}
-          echo '}' >> ${output}
-          cd ..
-          cp -r django-oauth2-test-source/* django-oauth2-test-source-git-info
   - put: cf-resource-prod
     params:
       current_app_name: django-oauth2-test-concourse-prod

--- a/pipelines/deployment.yml
+++ b/pipelines/deployment.yml
@@ -1217,8 +1217,8 @@ jobs:
   - put: cf-resource-ci
     params:
       current_app_name: django-oauth2-test-ci
-      manifest: django-oauth2-test-source-git-info/manifest.yml
-      path: django-oauth2-test-source-git-info
+      manifest: django-oauth2-test-source/manifest.yml
+      path: django-oauth2-test-source
       environment_variables:
         <<: *ci_security_user
         CSRF_ENABLED: 'True'
@@ -2152,8 +2152,8 @@ jobs:
   - put: cf-resource-latest
     params:
       current_app_name: django-oauth2-test-concourse-latest
-      manifest: django-oauth2-test-source-git-info/manifest.yml
-      path: django-oauth2-test-source-git-info
+      manifest: django-oauth2-test-source/manifest.yml
+      path: django-oauth2-test-source
       environment_variables:
         <<: *latest_security_user
         CSRF_ENABLED: 'True'
@@ -2964,8 +2964,8 @@ disabled-jobs:
   - put: cf-resource-preprod
     params:
       current_app_name: django-oauth2-test-concourse-preprod
-      manifest: django-oauth2-test-source-git-info/manifest.yml
-      path: django-oauth2-test-source-git-info
+      manifest: django-oauth2-test-source/manifest.yml
+      path: django-oauth2-test-source
       environment_variables:
         <<: *preprod_security_user
         CSRF_ENABLED: 'True'
@@ -3698,8 +3698,8 @@ disabled-jobs:
   - put: cf-resource-prod
     params:
       current_app_name: django-oauth2-test-concourse-prod
-      manifest: django-oauth2-test-source-git-info/manifest.yml
-      path: django-oauth2-test-source-git-info
+      manifest: django-oauth2-test-source/manifest.yml
+      path: django-oauth2-test-source
       environment_variables:
         <<: *prod_security_user
         CSRF_ENABLED: 'True'


### PR DESCRIPTION
# Motivation and Context
An image on DockerHub was removed by the owner. The source Dockerfile code can't be found on GitHub. We could try to find a drop-in replacement (distro with git) but why bother when this component is now deprecated?

# What has changed
Removed the broken bit, which depended upon a certain docker image.

# How to test?
Fly the pipeline. Check that the `django-oauth2-test-ci-deploy` job works and the ATs still pass OK.

# Links
Trello: https://trello.com/c/zX27SDMV
