### PR TITLE
Simplify build to work with go modules

### DIFF
--- a/pipelines/deployment.yml
+++ b/pipelines/deployment.yml
@@ -1641,7 +1641,7 @@ jobs:
           - |
             cd rm-survey-service-source
             make
-            cp manifest-preprod.yml ../survey-service
+            cp manifest.yml ../survey-service
             cp build/linux-amd64/bin/main ../survey-service/main
   - put: cf-resource-ci
     params:

--- a/pipelines/deployment.yml
+++ b/pipelines/deployment.yml
@@ -1632,23 +1632,18 @@ jobs:
             repository: golang
         inputs:
           - name: rm-survey-service-source
-        outputs:
-          - name: rm-survey-service-build
-            path: rm-survey-service
         run:
           path: sh
           args:
           - -exc
           - |
-            mkdir -p /go/src/github.com/ONSdigital/
-            cp -r rm-survey-service-source /go/src/github.com/ONSdigital/rm-survey-service
-            make -C /go/src/github.com/ONSdigital/rm-survey-service
-            cp -r /go/src/github.com/ONSdigital/rm-survey-service/ .
+            cd rm-survey-service-source
+            make
   - put: cf-resource-ci
     params:
       current_app_name: rm-survey-service-ci
       manifest: rm-survey-service-source/manifest.yml
-      path: rm-survey-service-build
+      path: rm-survey-service-source
       environment_variables:
         <<: *ci_security_user
         MIGRATION_SOURCE: 'file://db-migrations'
@@ -2542,23 +2537,18 @@ jobs:
             repository: golang
         inputs:
           - name: rm-survey-service-source
-        outputs:
-          - name: rm-survey-service-build
-            path: rm-survey-service
         run:
           path: sh
           args:
           - -exc
           - |
-            mkdir -p /go/src/github.com/ONSdigital/
-            cp -r rm-survey-service-source /go/src/github.com/ONSdigital/rm-survey-service
-            make -C /go/src/github.com/ONSdigital/rm-survey-service
-            cp -r /go/src/github.com/ONSdigital/rm-survey-service/ .
+            cd rm-survey-service-source
+            make
   - put: cf-resource-latest
     params:
       current_app_name: rm-survey-service-concourse-latest
       manifest: rm-survey-service-source/manifest.yml
-      path: rm-survey-service-build
+      path: rm-survey-service-source
       environment_variables:
         <<: *latest_security_user
         MIGRATION_SOURCE: 'file://db-migrations'
@@ -3346,23 +3336,18 @@ disabled-jobs:
             repository: golang
         inputs:
           - name: rm-survey-service-source
-        outputs:
-          - name: rm-survey-service-build
-            path: rm-survey-service
         run:
           path: sh
           args:
           - -exc
           - |
-            mkdir -p /go/src/github.com/ONSdigital/
-            cp -r rm-survey-service-source /go/src/github.com/ONSdigital/rm-survey-service
-            make -C /go/src/github.com/ONSdigital/rm-survey-service
-            cp -r /go/src/github.com/ONSdigital/rm-survey-service/ .
+            cd rm-survey-service-source
+            make
   - put: cf-resource-preprod
     params:
       current_app_name: rm-survey-service-concourse-preprod
       manifest: rm-survey-service-source/manifest.yml
-      path: rm-survey-service-build
+      path: rm-survey-service-source
       environment_variables:
         <<: *preprod_security_user
         MIGRATION_SOURCE: 'file://db-migrations'
@@ -4114,23 +4099,18 @@ disabled-jobs:
             repository: golang
         inputs:
           - name: rm-survey-service-source
-        outputs:
-          - name: rm-survey-service-build
-            path: rm-survey-service
         run:
           path: sh
           args:
           - -exc
           - |
-            mkdir -p /go/src/github.com/ONSdigital/
-            cp -r rm-survey-service-source /go/src/github.com/ONSdigital/rm-survey-service
-            make -C /go/src/github.com/ONSdigital/rm-survey-service
-            cp -r /go/src/github.com/ONSdigital/rm-survey-service/ .
+            cd rm-survey-service-source
+            make
   - put: cf-resource-prod
     params:
       current_app_name: rm-survey-service-concourse-prod
       manifest: rm-survey-service-source/manifest.yml
-      path: rm-survey-service-build
+      path: rm-survey-service-source
       environment_variables:
         <<: *prod_security_user
         MIGRATION_SOURCE: 'file://db-migrations'

--- a/pipelines/deployment.yml
+++ b/pipelines/deployment.yml
@@ -1647,6 +1647,7 @@ jobs:
     params:
       current_app_name: rm-survey-service-ci
       manifest: survey-service/manifest.yml
+      path: survey-service
       environment_variables:
         <<: *ci_security_user
         MIGRATION_SOURCE: 'file://db-migrations'

--- a/pipelines/deployment.yml
+++ b/pipelines/deployment.yml
@@ -1639,10 +1639,8 @@ jobs:
           args:
           - -exc
           - |
-            cd rm-survey-service-source
-            make
-            cp manifest.yml ../survey-service
-            cp build/linux-amd64/bin/main ../survey-service/main
+            cp -r rm-survey-service-source/* survey-service
+            make -C survey-service
   - put: cf-resource-ci
     params:
       current_app_name: rm-survey-service-ci
@@ -2541,18 +2539,20 @@ jobs:
             repository: golang
         inputs:
           - name: rm-survey-service-source
+        outputs:
+          - name: survey-service
         run:
           path: sh
           args:
           - -exc
           - |
-            cd rm-survey-service-source
-            make
+            cp -r rm-survey-service-source/* survey-service
+            make -C survey-service
   - put: cf-resource-latest
     params:
       current_app_name: rm-survey-service-concourse-latest
-      manifest: rm-survey-service-source/manifest.yml
-      path: rm-survey-service-source
+      manifest: survey-service/manifest.yml
+      path: survey-service
       environment_variables:
         <<: *latest_security_user
         MIGRATION_SOURCE: 'file://db-migrations'
@@ -3340,18 +3340,20 @@ disabled-jobs:
             repository: golang
         inputs:
           - name: rm-survey-service-source
+        outputs:
+          - name: survey-service
         run:
           path: sh
           args:
           - -exc
           - |
-            cd rm-survey-service-source
-            make
+            cp -r rm-survey-service-source/* survey-service
+            make -C survey-service
   - put: cf-resource-preprod
     params:
       current_app_name: rm-survey-service-concourse-preprod
-      manifest: rm-survey-service-source/manifest.yml
-      path: rm-survey-service-source
+      manifest: survey-service/manifest.yml
+      path: survey-service
       environment_variables:
         <<: *preprod_security_user
         MIGRATION_SOURCE: 'file://db-migrations'
@@ -4103,18 +4105,20 @@ disabled-jobs:
             repository: golang
         inputs:
           - name: rm-survey-service-source
+        outputs:
+          - name: survey-service
         run:
           path: sh
           args:
           - -exc
           - |
-            cd rm-survey-service-source
-            make
+            cp -r rm-survey-service-source/* survey-service
+            make -C survey-service
   - put: cf-resource-prod
     params:
       current_app_name: rm-survey-service-concourse-prod
-      manifest: rm-survey-service-source/manifest.yml
-      path: rm-survey-service-source
+      manifest: survey-service/manifest.yml
+      path: survey-service
       environment_variables:
         <<: *prod_security_user
         MIGRATION_SOURCE: 'file://db-migrations'

--- a/pipelines/deployment.yml
+++ b/pipelines/deployment.yml
@@ -1632,6 +1632,8 @@ jobs:
             repository: golang
         inputs:
           - name: rm-survey-service-source
+        outputs:
+          - name: survey-service
         run:
           path: sh
           args:
@@ -1639,11 +1641,12 @@ jobs:
           - |
             cd rm-survey-service-source
             make
+            cp manifest-preprod.yml ../survey-service
+            cp build/linux-amd64/bin/main ../survey-service/main
   - put: cf-resource-ci
     params:
       current_app_name: rm-survey-service-ci
-      manifest: rm-survey-service-source/manifest.yml
-      path: rm-survey-service-source
+      manifest: survey-service/manifest.yml
       environment_variables:
         <<: *ci_security_user
         MIGRATION_SOURCE: 'file://db-migrations'

--- a/pipelines/performance.yml
+++ b/pipelines/performance.yml
@@ -847,15 +847,13 @@ jobs:
           args:
           - -exc
           - |
-            mkdir -p /go/src/github.com/ONSdigital/
-            cp -r rm-survey-service-source /go/src/github.com/ONSdigital/rm-survey-service
-            make -C /go/src/github.com/ONSdigital/rm-survey-service
-            cp -r /go/src/github.com/ONSdigital/rm-survey-service/ .
+            cd rm-survey-service-source
+            make
   - put: cf-resource-((performance_cloudfoundry_space))
     params:
       current_app_name: rm-survey-service-((performance_cloudfoundry_space))
       manifest: rm-survey-service-source/manifest.yml
-      path: rm-survey-service-build
+      path: rm-survey-service-source
       environment_variables:
         <<: *performance_security_user
         MIGRATION_SOURCE: 'file://db-migrations'

--- a/pipelines/survey-service.yml
+++ b/pipelines/survey-service.yml
@@ -86,16 +86,15 @@ jobs:
           repository: golang
       inputs:
         - name: survey-service-pre-release-source
+      outputs:
+        - name: survey-service
       run:
         path: sh
         args:
         - -exc
         - |
-          # Keep the source where it is. No need to move under the GOPATH as
-          # we're using `go modules` that operate outside. Dependencies are
-          # pulled in when `go build` is run in `make`
-          cd survey-service-pre-release-source
-          make
+          cp -r survey-service-pre-release-source/* survey-service
+          make -C survey-service
   - put: push-app
     resource: cf-resource-preprod
     on_failure:
@@ -106,8 +105,8 @@ jobs:
           $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
     params:
       current_app_name: surveysvc-preprod
-      manifest: survey-service-pre-release-source/manifest-preprod.yml
-      path: survey-service-pre-release-source
+      manifest: survey-service/manifest-preprod.yml
+      path: survey-service
       environment_variables:
         MIGRATION_SOURCE: ((preprod_survey_migration_source))
         security_user_name: ((preprod_security_user_name))
@@ -135,16 +134,15 @@ jobs:
           repository: golang
       inputs:
         - name: survey-service-release-source
+      outputs:
+        - name: survey-service
       run:
         path: sh
         args:
         - -exc
         - |
-          # Keep the source where it is. No need to move under the GOPATH as
-          # we're using `go modules` that operate outside. Dependencies are
-          # pulled in when `go build` is run in `make`
-          cd survey-service-release-source
-          make
+          cp -r survey-service-release-source/* survey-service
+          make -C survey-service
   - put: push-app
     resource: cf-resource-prod
     on_failure:
@@ -155,8 +153,8 @@ jobs:
           $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
     params:
       current_app_name: surveysvc-prod
-      manifest: survey-service-release-source/manifest-prod.yml
-      path: rm-survey-service-source
+      manifest: survey-service/manifest-prod.yml
+      path: survey-service
       environment_variables:
         MIGRATION_SOURCE: ((prod_survey_migration_source))
         security_user_name: ((prod_security_user_name))

--- a/pipelines/survey-service.yml
+++ b/pipelines/survey-service.yml
@@ -70,7 +70,7 @@ jobs:
   plan:
   - get: survey-service-pre-release
     trigger: true
-    params: 
+    params:
       include_source_tarball: true
   - get: ras-deploy
   - task: extract-source-from-release-tarball
@@ -86,18 +86,16 @@ jobs:
           repository: golang
       inputs:
         - name: survey-service-pre-release-source
-      outputs:
-        - name: rm-survey-service-build
-          path: rm-survey-service
       run:
         path: sh
         args:
         - -exc
         - |
-          mkdir -p /go/src/github.com/ONSdigital/
-          cp -r survey-service-pre-release-source /go/src/github.com/ONSdigital/rm-survey-service
-          make -C /go/src/github.com/ONSdigital/rm-survey-service
-          cp -r /go/src/github.com/ONSdigital/rm-survey-service/ .
+          # Keep the source where it is. No need to move under the GOPATH as
+          # we're using `go modules` that operate outside. Dependencies are
+          # pulled in when `go build` is run in `make`
+          cd survey-service-pre-release-source
+          make
   - put: push-app
     resource: cf-resource-preprod
     on_failure:
@@ -109,7 +107,7 @@ jobs:
     params:
       current_app_name: surveysvc-preprod
       manifest: survey-service-pre-release-source/manifest-preprod.yml
-      path: rm-survey-service-build
+      path: survey-service-pre-release-source
       environment_variables:
         MIGRATION_SOURCE: ((preprod_survey_migration_source))
         security_user_name: ((preprod_security_user_name))
@@ -137,21 +135,18 @@ jobs:
           repository: golang
       inputs:
         - name: survey-service-release-source
-      outputs:
-        - name: rm-survey-service-build
-          path: rm-survey-service
       run:
         path: sh
         args:
         - -exc
         - |
-          mkdir -p /go/src/github.com/ONSdigital/
-          cp -r survey-service-release-source /go/src/github.com/ONSdigital/rm-survey-service
-          make -C /go/src/github.com/ONSdigital/rm-survey-service
-          cp -r /go/src/github.com/ONSdigital/rm-survey-service/ .
+          # Keep the source where it is. No need to move under the GOPATH as
+          # we're using `go modules` that operate outside. Dependencies are
+          # pulled in when `go build` is run in `make`
+          cd survey-service-release-source
+          make
   - put: push-app
     resource: cf-resource-prod
-
     on_failure:
       put: notify
       params:
@@ -161,7 +156,7 @@ jobs:
     params:
       current_app_name: surveysvc-prod
       manifest: survey-service-release-source/manifest-prod.yml
-      path: rm-survey-service-build
+      path: rm-survey-service-source
       environment_variables:
         MIGRATION_SOURCE: ((prod_survey_migration_source))
         security_user_name: ((prod_security_user_name))


### PR DESCRIPTION
# Motivation and Context

This updates the `add-survey-service-deployment` branch to work with the updated [rm-survey-service (pr)](https://github.com/ONSdigital/rm-survey-service/pull/70)

# What has changed

Simplified build step as `go modules` will now pull in pinned dependencies on `go build` which is run in `make`.

Removed some of the extraneous `cd`ing around folders which wasn't required and just complicated the process.

# How to test?

- Fly to a concourse with appropriate configuration
- Trigger pipeline
- Pipeline should run and deploy the application

> n.b. As this pipeline expects to triggered off a release, the only way to trigger it is either to cut another release tag or amend the resources to pull from a normal git commit.

# Links

- Associated PR: https://github.com/ONSdigital/rm-survey-service/pull/70
