### PR TITLE
Add missing services and config to ci and latest

### DIFF
--- a/pipelines/deployment.yml
+++ b/pipelines/deployment.yml
@@ -45,7 +45,7 @@ templates:
 
     all_services: &ci_all_services
     - ras-party-ci-deploy
-    - ras-rabbit-adaptor-service-deploy
+    - ras-rabbit-adaptor-service-ci-deploy
     - rm-reporting-ci-deploy
     - ras-maintenance-ci-deploy
     - ras-frontstage-ci-deploy
@@ -248,9 +248,9 @@ templates:
 
     all_services: &latest_all_services
     - ras-party-latest-deploy
-    - ras-rabbit-adaptor-service-deploy
-    - rm-reporting-ci-deploy
-    - ras-maintenance-ci-deploy
+    - ras-rabbit-adaptor-service-latest-deploy
+    - rm-reporting-latest-deploy
+    - ras-maintenance-latest-deploy
     - ras-frontstage-latest-deploy
     - django-oauth2-test-latest-deploy
     - ras-rm-auth-service-latest-deploy
@@ -725,7 +725,7 @@ jobs:
       manifest: ras-maintenance-source/manifest.yml
       path: ras-maintenance-source
       environment_variables:
-        MAINTENANCE_TEMPLATE: ((maintenance_template))
+        MAINTENANCE_TEMPLATE: ((ci_maintenance_template))
 
 - name: ras-secure-message-ci-deploy
   serial_groups: [ras-secure-message-ci-deploy]
@@ -1734,7 +1734,7 @@ jobs:
       manifest: ras-maintenance-source/manifest.yml
       path: ras-maintenance-source
       environment_variables:
-        MAINTENANCE_TEMPLATE: ((maintenance_template))
+        MAINTENANCE_TEMPLATE: ((latest_maintenance_template))
 
 - name: ras-secure-message-latest-deploy
   serial_groups: [ras-secure-message-latest-deploy]

--- a/pipelines/deployment.yml
+++ b/pipelines/deployment.yml
@@ -1492,6 +1492,15 @@ jobs:
   - get: sdc-uaa-source
     passed: [uaa-ci-deploy]
     trigger: true
+  - get: ras-maintenance-source
+    passed: [ras-maintenance-ci-deploy]
+    trigger: true
+  - get: rm-reporting-source
+    passed: [rm-reporting-ci-deploy]
+    trigger: true
+  - get: ras-rabbit-adaptor-service-source
+    passed: [ras-rabbit-adaptor-service-ci-deploy]
+    trigger: true
   - task: get-cf-database-uris
     file: ras-deploy/tasks/get_database_uris.yml
     params:
@@ -1604,6 +1613,15 @@ jobs:
   - get: sdc-uaa-source
     passed: [uaa-ci-deploy]
     trigger: true
+  - get: ras-maintenance-source
+    passed: [ras-maintenance-ci-deploy]
+    trigger: true
+  - get: rm-reporting-source
+    passed: [rm-reporting-ci-deploy]
+    trigger: true
+  - get: ras-rabbit-adaptor-service-source
+    passed: [ras-rabbit-adaptor-service-ci-deploy]
+    trigger: true
   - task: get-cf-database-uris
     file: ras-deploy/tasks/get_database_uris.yml
     params:
@@ -1683,6 +1701,7 @@ jobs:
   plan:
   - get: ras-rabbit-adaptor-service-source
     trigger: true
+    passed: [ci-rasrm-acceptance-tests, ci-securemessage-acceptance-tests]
   - put: create-rm-rabbitmq
     resource: cf-cli-resource-latest
     params:
@@ -1693,7 +1712,7 @@ jobs:
       timeout: 1800
       wait_for_service: true
   - put: push-app
-    resource: cf-resource-ci
+    resource: cf-resource-latest
     params:
       current_app_name: ci-rabbit-adapter-latest # Note: adapter spelt with 'er' where all the others are 'or'
       manifest: ras-rabbit-adaptor-service-source/manifest.yml
@@ -1714,6 +1733,7 @@ jobs:
   plan:
   - get: rm-reporting-source
     trigger: true
+    passed: [ci-rasrm-acceptance-tests, ci-securemessage-acceptance-tests]
   - put: create-database
     resource: cf-cli-resource-latest
     params:
@@ -1737,6 +1757,7 @@ jobs:
   plan:
   - get: ras-maintenance-source
     trigger: true
+    passed: [ci-rasrm-acceptance-tests, ci-securemessage-acceptance-tests]
   - put: push-app
     resource: cf-resource-latest
     params:

--- a/pipelines/deployment.yml
+++ b/pipelines/deployment.yml
@@ -708,7 +708,7 @@ jobs:
       command: create-service
       service: rds
       plan: shared-psql
-      service_instance: rm-reporting-db
+      service_instance: reporting-db
       timeout: 300
       wait_for_service: true
   - put: push-app
@@ -1740,7 +1740,7 @@ jobs:
       command: create-service
       service: rds
       plan: shared-psql
-      service_instance: rm-reporting-db
+      service_instance: reporting-db
       timeout: 300
       wait_for_service: true
   - put: push-app

--- a/pipelines/deployment.yml
+++ b/pipelines/deployment.yml
@@ -677,7 +677,7 @@ jobs:
         <<: *ci_security_user
         <<: *ci_service_endpoints_for_python
         CI_SECRETS: ((ci_json_rabbit_adaptor_secret_keys))
-        COLLEX_ID: 'cfc6c8a4-109b-41f8-822f-5b7c0e25f850' # TODO: Find a valid collex_id in ci
+        COLLEX_ID: 'a9ef1f12-23f4-413e-938c-8078df1bb170'
         EXCHANGE_TYPE: 'topic'
         RABBIT_EXCHANGE: 'messages'
         RABBIT_QUARANTINE_QUEUE: 'Seft.CollectionInstruments.Quarantine'
@@ -1692,7 +1692,7 @@ jobs:
         <<: *latest_security_user
         <<: *latest_service_endpoints_for_python
         CI_SECRETS: ((latest_json_rabbit_adaptor_secret_keys))
-        COLLEX_ID: 'cfc6c8a4-109b-41f8-822f-5b7c0e25f850' # TODO: Find a valid collex_id in latest
+        COLLEX_ID: '3f93d816-424c-4a3f-9d0b-4f58a286bc20'
         EXCHANGE_TYPE: 'topic'
         RABBIT_EXCHANGE: 'messages'
         RABBIT_QUARANTINE_QUEUE: 'Seft.CollectionInstruments.Quarantine'

--- a/pipelines/deployment.yml
+++ b/pipelines/deployment.yml
@@ -543,6 +543,16 @@ resources:
   type: git
   source:
     uri: https://github.com/ONSdigital/sdc-uaa.git
+
+- name: rm-reporting-source
+  type: git
+  source:
+    uri: https://github.com/ONSdigital/rm-reporting.git
+
+- name: ras-maintenance-source
+  type: git
+  source:
+    uri: https://github.com/ONSdigital/ras-maintenance-page.git
 ### END MICROSERVICE REPOS
 
 - name: rasrm-acceptance-tests-source

--- a/pipelines/deployment.yml
+++ b/pipelines/deployment.yml
@@ -676,7 +676,7 @@ jobs:
       environment_variables:
         <<: *ci_security_user
         <<: *ci_service_endpoints_for_python
-        CI_SECRETS: ((ci_json_rabbit_adaptor_secret_keys))
+        CI_SECRETS: ((preprod_json_secret_keys)) # Sharing preprod as CI/Latest don't exist in SDX
         COLLEX_ID: 'a9ef1f12-23f4-413e-938c-8078df1bb170'
         EXCHANGE_TYPE: 'topic'
         RABBIT_EXCHANGE: 'messages'
@@ -1691,7 +1691,7 @@ jobs:
       environment_variables:
         <<: *latest_security_user
         <<: *latest_service_endpoints_for_python
-        CI_SECRETS: ((latest_json_rabbit_adaptor_secret_keys))
+        CI_SECRETS: ((preprod_json_secret_keys)) # Using preprod as CI/Latest don't exist in SDX
         COLLEX_ID: '3f93d816-424c-4a3f-9d0b-4f58a286bc20'
         EXCHANGE_TYPE: 'topic'
         RABBIT_EXCHANGE: 'messages'

--- a/pipelines/deployment.yml
+++ b/pipelines/deployment.yml
@@ -45,6 +45,9 @@ templates:
 
     all_services: &ci_all_services
     - ras-party-ci-deploy
+    - ras-rabbit-adaptor-service-deploy
+    - rm-reporting-ci-deploy
+    - ras-maintenance-ci-deploy
     - ras-frontstage-ci-deploy
     - django-oauth2-test-ci-deploy
     - ras-rm-auth-service-ci-deploy
@@ -245,6 +248,9 @@ templates:
 
     all_services: &latest_all_services
     - ras-party-latest-deploy
+    - ras-rabbit-adaptor-service-deploy
+    - rm-reporting-ci-deploy
+    - ras-maintenance-ci-deploy
     - ras-frontstage-latest-deploy
     - django-oauth2-test-latest-deploy
     - ras-rm-auth-service-latest-deploy
@@ -424,6 +430,12 @@ resources:
   type: git
   source:
     uri: https://github.com/ONSdigital/ras-party.git
+    branch: master
+
+- name: ras-rabbit-adaptor-service-source
+  type: git
+  source:
+    uri: https://github.com/ONSdigital/ras-rabbit-adaptor-service.git
     branch: master
 
 - name: ras-secure-message-source
@@ -637,6 +649,83 @@ jobs:
         RAS_NOTIFY_EMAIL_VERIFICATION_TEMPLATE: 53c59576-8c3b-4298-99d1-b245ddd28500
         RAS_NOTIFY_REQUEST_PASSWORD_CHANGE_TEMPLATE: c45c59ff-7771-4de4-a66b-ce50b108390a
         RAS_NOTIFY_SERVICE_URL: http://notifygatewaysvc-ci.apps.devtest.onsclofo.uk/emails/
+
+- name: ras-rabbit-adaptor-service-ci-deploy
+  serial_groups: [ras-rabbit-adaptor-service-ci-deploy]
+  plan:
+  - get: ras-rabbit-adaptor-service-source
+    trigger: true
+  - get: ci-teardown-timer
+    trigger: true
+    passed: [ci-teardown]
+  - put: create-rm-rabbitmq
+    resource: cf-cli-resource-ci
+    params:
+      command: create-service
+      service: rabbitmq
+      plan: standard
+      service_instance: rm-rabbitmq
+      timeout: 1800
+      wait_for_service: true
+  - put: push-app
+    resource: cf-resource-ci
+    params:
+      current_app_name: ci-rabbit-adapter-ci # Note: adapter spelt with 'er' where all the others are 'or'
+      manifest: ras-rabbit-adaptor-service-source/manifest.yml
+      path: ras-rabbit-adaptor-service-source
+      environment_variables:
+        <<: *ci_security_user
+        <<: *ci_service_endpoints_for_python
+        CI_SECRETS: ((ci_json_rabbit_adaptor_secret_keys))
+        COLLEX_ID: 'cfc6c8a4-109b-41f8-822f-5b7c0e25f850' # TODO: Find a valid collex_id in ci
+        EXCHANGE_TYPE: 'topic'
+        RABBIT_EXCHANGE: 'messages'
+        RABBIT_QUARANTINE_QUEUE: 'Seft.CollectionInstruments.Quarantine'
+        RABBIT_QUEUE: 'Seft.CollectionInstruments'
+        RABBIT_URL: ((ci_rabbit_adaptor_rabbit_url))
+
+- name: rm-reporting-ci-deploy
+  serial_groups: [rm-reporting-ci-deploy]
+  plan:
+  - get: rm-reporting-source
+    trigger: true
+  - get: ci-teardown-timer
+    trigger: true
+    passed: [ci-teardown]
+  - put: create-database
+    resource: cf-cli-resource-ci
+    params:
+      command: create-service
+      service: rds
+      plan: shared-psql
+      service_instance: secure-message-db
+      timeout: 300
+      wait_for_service: true
+  - put: push-app
+    resource: cf-resource-ci
+    params:
+      current_app_name: rm-reporting-ci
+      manifest: rm-reporting-source/manifest.yml
+      path: rm-reporting-source
+      environment_variables:
+        <<: *ci_security_user
+
+- name: ras-maintenance-ci-deploy
+  serial_groups: [ras-maintenance-ci-deploy]
+  plan:
+  - get: ras-maintenance-source
+    trigger: true
+  - get: ci-teardown-timer
+    trigger: true
+    passed: [ci-teardown]
+  - put: push-app
+    resource: cf-resource-ci
+    params:
+      current_app_name: ras-maintenance-ci
+      manifest: ras-maintenance-source/manifest.yml
+      path: ras-maintenance-source
+      environment_variables:
+        MAINTENANCE_TEMPLATE: ((maintenance_template))
 
 - name: ras-secure-message-ci-deploy
   serial_groups: [ras-secure-message-ci-deploy]
@@ -1324,6 +1413,7 @@ jobs:
         path: sh
         args:
         - './scripts/jenkins/add_user.sh'
+
 ### END CI DEPLOYMENTS
 
 - name: ci-rasrm-acceptance-tests
@@ -1577,6 +1667,74 @@ jobs:
         RAS_NOTIFY_EMAIL_VERIFICATION_TEMPLATE: 53c59576-8c3b-4298-99d1-b245ddd28500
         RAS_NOTIFY_REQUEST_PASSWORD_CHANGE_TEMPLATE: c45c59ff-7771-4de4-a66b-ce50b108390a
         RAS_NOTIFY_SERVICE_URL: http://notifygatewaysvc-latest.apps.devtest.onsclofo.uk/emails/
+
+- name: ras-rabbit-adaptor-service-latest-deploy
+  serial_groups: [ras-rabbit-adaptor-service-latest-deploy]
+  plan:
+  - get: ras-rabbit-adaptor-service-source
+    trigger: true
+  - put: create-rm-rabbitmq
+    resource: cf-cli-resource-latest
+    params:
+      command: create-service
+      service: rabbitmq
+      plan: standard
+      service_instance: rm-rabbitmq
+      timeout: 1800
+      wait_for_service: true
+  - put: push-app
+    resource: cf-resource-ci
+    params:
+      current_app_name: ci-rabbit-adapter-latest # Note: adapter spelt with 'er' where all the others are 'or'
+      manifest: ras-rabbit-adaptor-service-source/manifest.yml
+      path: ras-rabbit-adaptor-service-source
+      environment_variables:
+        <<: *latest_security_user
+        <<: *latest_service_endpoints_for_python
+        CI_SECRETS: ((latest_json_rabbit_adaptor_secret_keys))
+        COLLEX_ID: 'cfc6c8a4-109b-41f8-822f-5b7c0e25f850' # TODO: Find a valid collex_id in latest
+        EXCHANGE_TYPE: 'topic'
+        RABBIT_EXCHANGE: 'messages'
+        RABBIT_QUARANTINE_QUEUE: 'Seft.CollectionInstruments.Quarantine'
+        RABBIT_QUEUE: 'Seft.CollectionInstruments'
+        RABBIT_URL: ((ci_rabbit_adaptor_rabbit_url))
+
+- name: rm-reporting-latest-deploy
+  serial_groups: [rm-reporting-latest-deploy]
+  plan:
+  - get: rm-reporting-source
+    trigger: true
+  - put: create-database
+    resource: cf-cli-resource-latest
+    params:
+      command: create-service
+      service: rds
+      plan: shared-psql
+      service_instance: secure-message-db
+      timeout: 300
+      wait_for_service: true
+  - put: push-app
+    resource: cf-resource-latest
+    params:
+      current_app_name: rm-reporting-latest
+      manifest: rm-reporting-source/manifest.yml
+      path: rm-reporting-source
+      environment_variables:
+        <<: *latest_security_user
+
+- name: ras-maintenance-latest-deploy
+  serial_groups: [ras-maintenance-latest-deploy]
+  plan:
+  - get: ras-maintenance-source
+    trigger: true
+  - put: push-app
+    resource: cf-resource-latest
+    params:
+      current_app_name: ras-maintenance-latest
+      manifest: ras-maintenance-source/manifest.yml
+      path: ras-maintenance-source
+      environment_variables:
+        MAINTENANCE_TEMPLATE: ((maintenance_template))
 
 - name: ras-secure-message-latest-deploy
   serial_groups: [ras-secure-message-latest-deploy]

--- a/pipelines/deployment.yml
+++ b/pipelines/deployment.yml
@@ -708,7 +708,7 @@ jobs:
       command: create-service
       service: rds
       plan: shared-psql
-      service_instance: secure-message-db
+      service_instance: rm-reporting-db
       timeout: 300
       wait_for_service: true
   - put: push-app
@@ -1740,7 +1740,7 @@ jobs:
       command: create-service
       service: rds
       plan: shared-psql
-      service_instance: secure-message-db
+      service_instance: rm-reporting-db
       timeout: 300
       wait_for_service: true
   - put: push-app

--- a/pipelines/deployment.yml
+++ b/pipelines/deployment.yml
@@ -682,7 +682,7 @@ jobs:
         RABBIT_EXCHANGE: 'messages'
         RABBIT_QUARANTINE_QUEUE: 'Seft.CollectionInstruments.Quarantine'
         RABBIT_QUEUE: 'Seft.CollectionInstruments'
-        RABBIT_URL: ((ci_rabbit_adaptor_rabbit_url))
+        RABBIT_URL: ((ci_rabbitmq_amqp_survey_response))
 
 - name: rm-reporting-ci-deploy
   serial_groups: [rm-reporting-ci-deploy]
@@ -1691,13 +1691,13 @@ jobs:
       environment_variables:
         <<: *latest_security_user
         <<: *latest_service_endpoints_for_python
-        CI_SECRETS: ((preprod_json_secret_keys)) # Using preprod as CI/Latest don't exist in SDX
+        CI_SECRETS: ((preprod_json_secret_keys)) # Sharing preprod as CI/Latest don't exist in SDX
         COLLEX_ID: '3f93d816-424c-4a3f-9d0b-4f58a286bc20'
         EXCHANGE_TYPE: 'topic'
         RABBIT_EXCHANGE: 'messages'
         RABBIT_QUARANTINE_QUEUE: 'Seft.CollectionInstruments.Quarantine'
         RABBIT_QUEUE: 'Seft.CollectionInstruments'
-        RABBIT_URL: ((ci_rabbit_adaptor_rabbit_url))
+        RABBIT_URL: ((latest_rabbitmq_amqp_survey_response))
 
 - name: rm-reporting-latest-deploy
   serial_groups: [rm-reporting-latest-deploy]

--- a/secrets/deployment.yml.example
+++ b/secrets/deployment.yml.example
@@ -32,7 +32,9 @@ ci_oauth2_super_user_email:
 ci_oauth2_super_user_password:
 ci_rabbitmq_amqp_collection_instrument:
 ci_rabbitmq_amqp_survey_response:
+ci_rabbit_adaptor_rabbit_url:
 ci_json_secret_keys:
+ci_json_rabbit_adaptor_secret_keys:
 ci_secure_message_client_secret:
 ci_response_operations_client_secret:
 ci_response_operations_social_client_secret:
@@ -59,7 +61,9 @@ latest_oauth2_super_user_email:
 latest_oauth2_super_user_password:
 latest_rabbitmq_amqp_collection_instrument:
 latest_rabbitmq_amqp_survey_response:
+latest_rabbit_adaptor_rabbit_url:
 latest_json_secret_keys:
+latest_json_rabbit_adaptor_secret_keys:
 latest_secure_message_client_secret:
 latest_response_operations_client_secret:
 latest_response_operations_social_client_secret:

--- a/secrets/deployment.yml.example
+++ b/secrets/deployment.yml.example
@@ -27,6 +27,7 @@ sample_sftp_username:
 ci_security_user_name:
 ci_security_user_password:
 ci_jwt_secret:
+ci_maintenance_template:
 ci_oauth2_super_user:
 ci_oauth2_super_user_email:
 ci_oauth2_super_user_password:
@@ -56,6 +57,7 @@ ci_uaa_user_password:
 latest_security_user_name:
 latest_security_user_password:
 latest_jwt_secret:
+latest_maintenance_template:
 latest_oauth2_super_user:
 latest_oauth2_super_user_email:
 latest_oauth2_super_user_password:


### PR DESCRIPTION
# Motivation and Context
The adaptor-service, rm-reporting and ras-maintainence weren't in the ci or latest pipeline.  This adds them so the list of services running in those environments is closer to preprod/prod

# What has changed
Added missing services and config

# How to test?
Fly pipeline, make sure the services work?

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
